### PR TITLE
add duplicate block proof sigverify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6372,7 +6372,6 @@ dependencies = [
 name = "spl-slashing"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "bincode",
  "bitflags 2.7.0",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -614,7 +614,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -1059,7 +1059,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "subtle",
 ]
 
@@ -1221,7 +1221,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1681,16 +1681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb8bc4c28d15ade99c7e90b219f30da4be5c88e586277e8cbe886beeb868ab2"
-dependencies = [
- "serde",
- "typenum",
-]
-
-[[package]]
 name = "gethostname"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,7 +1907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
- "generic-array 0.14.7",
+ "generic-array",
  "hmac 0.8.1",
 ]
 
@@ -2305,7 +2295,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -5695,7 +5685,7 @@ checksum = "29cb6cae156bc2c80ae34b2b365cf460be974cf5c68799e7024615f88f54aed4"
 dependencies = [
  "bs58",
  "ed25519-dalek",
- "generic-array 0.14.7",
+ "generic-array",
  "rand 0.8.5",
  "serde",
  "serde_derive",
@@ -6382,10 +6372,10 @@ dependencies = [
 name = "spl-slashing"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "bincode",
  "bitflags 2.7.0",
  "bytemuck",
- "generic-array 1.1.1",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -6401,6 +6391,7 @@ dependencies = [
  "solana-program",
  "solana-program-test",
  "solana-sdk",
+ "solana-signature",
  "spl-pod 0.5.0",
  "spl-record",
  "thiserror 2.0.10",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,14 +12,15 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
+arrayvec = "0.7.6"
 bitflags = { version = "2.7.0", features = ["serde"] }
 bytemuck = { version = "1.21.0", features = ["derive"] }
 num_enum = "0.7.3"
-generic-array = { version = "1.1.1", features = ["serde"], default-features = false }
 bincode = "1.3.3"
 num-derive = "0.4"
 num-traits = "0.2"
 solana-program = "2.1.0"
+solana-signature = "2.1.0"
 serde = "1.0.217" # must match the serde_derive version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251
 serde_bytes = "0.11.15"
 serde_derive = "1.0.210" # must match the serde version, see https://github.com/serde-rs/serde/issues/2584#issuecomment-1685252251

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -12,7 +12,6 @@ no-entrypoint = []
 test-sbf = []
 
 [dependencies]
-arrayvec = "0.7.6"
 bitflags = { version = "2.7.0", features = ["serde"] }
 bytemuck = { version = "1.21.0", features = ["derive"] }
 num_enum = "0.7.3"

--- a/program/src/duplicate_block_proof.rs
+++ b/program/src/duplicate_block_proof.rs
@@ -384,7 +384,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            instruction::{construct_instructions_and_sysvar, DuplicateBlockProofSigverifyData},
+            instruction::{construct_instructions_and_sysvar, DuplicateBlockProofInstructionData},
             shred::{
                 tests::{new_rand_coding_shreds, new_rand_data_shred, new_rand_shreds},
                 SIZE_OF_SIGNATURE,
@@ -396,6 +396,7 @@ mod tests {
             signature::{Keypair, Signature, Signer},
             sysvar::instructions,
         },
+        spl_pod::primitives::PodU64,
         std::sync::Arc,
     };
 
@@ -433,15 +434,18 @@ mod tests {
     #[test]
     fn test_unpack_context() {
         let node_pubkey = Pubkey::new_unique();
-        let sigverify_data = DuplicateBlockProofSigverifyData {
+        let slot = 100;
+        let instruction_data = DuplicateBlockProofInstructionData {
+            slot: PodU64::from(slot),
+            offset: PodU64::from(0),
+            node_pubkey,
             shred_1_merkle_root: Hash::new_unique(),
             shred_1_signature: Signature::new_unique().into(),
             shred_2_merkle_root: Hash::new_unique(),
             shred_2_signature: Signature::new_unique().into(),
         };
-        let slot = 100;
         let (instructions, mut instructions_sysvar_data) =
-            construct_instructions_and_sysvar(node_pubkey, slot, &sigverify_data);
+            construct_instructions_and_sysvar(&instruction_data);
         let mut lamports = 0;
         let instructions_sysvar = AccountInfo::new(
             &instructions::ID,
@@ -460,19 +464,19 @@ mod tests {
         assert_eq!(*context.expected_pubkey, node_pubkey);
         assert_eq!(
             *context.expected_shred1_merkle_root,
-            sigverify_data.shred_1_merkle_root
+            instruction_data.shred_1_merkle_root
         );
         assert_eq!(
             *context.expected_shred2_merkle_root,
-            sigverify_data.shred_2_merkle_root
+            instruction_data.shred_2_merkle_root
         );
         assert_eq!(
             *context.expected_shred1_signature,
-            sigverify_data.shred_1_signature
+            instruction_data.shred_1_signature
         );
         assert_eq!(
             *context.expected_shred2_signature,
-            sigverify_data.shred_2_signature
+            instruction_data.shred_2_signature
         );
     }
 

--- a/program/src/duplicate_block_proof.rs
+++ b/program/src/duplicate_block_proof.rs
@@ -32,8 +32,8 @@ const NUM_VERIFICATIONS_IN_INSTRUCTION: usize = 2;
 pub struct DuplicateBlockProofContext<'a> {
     pub(crate) expected_pubkey: &'a Pubkey,
     pub(crate) expected_shred1_merkle_root: &'a Hash,
-    pub(crate) expected_shred2_merkle_root: &'a Hash,
     pub(crate) expected_shred1_signature: &'a [u8; SIGNATURE_BYTES],
+    pub(crate) expected_shred2_merkle_root: &'a Hash,
     pub(crate) expected_shred2_signature: &'a [u8; SIGNATURE_BYTES],
 }
 
@@ -68,8 +68,8 @@ impl<'a> DuplicateBlockProofContext<'a> {
         Ok(Self {
             expected_pubkey: signature_verifications[0].pubkey,
             expected_shred1_merkle_root,
-            expected_shred2_merkle_root,
             expected_shred1_signature: signature_verifications[0].signature,
+            expected_shred2_merkle_root,
             expected_shred2_signature: signature_verifications[1].signature,
         })
     }
@@ -321,7 +321,7 @@ fn check_shreds(slot: Slot, shred1: &Shred, shred2: &Shred) -> Result<(), Slashi
 }
 
 /// Verify that `shred1` and `shred2` are correctly signed by `node_pubkey`.
-/// Leader's sign the merkle root of each shred with their pubkey.
+/// Leaders sign the merkle root of each shred with their pubkey.
 /// We use the context returned via instruction introspection to verify that
 /// instructions representing:
 ///     - `node_pubkey.verify(shred1.signature, shred1.merkle_root)`
@@ -1133,9 +1133,9 @@ mod tests {
             new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true, true);
 
         let (proof_data, context) = generate_proof_data(&leader_pubkey, &shred1, &shred2);
-        assert!(proof_data
+        proof_data
             .verify_proof(context, SLOT, &leader_pubkey)
-            .is_ok());
+            .unwrap();
 
         let bad_pubkey = Pubkey::new_unique();
         let bad_merkle_root = Hash::new_unique();

--- a/program/src/duplicate_block_proof.rs
+++ b/program/src/duplicate_block_proof.rs
@@ -408,13 +408,10 @@ mod tests {
     fn generate_proof_data<'a>(
         leader: &'a Pubkey,
         shred1: &'a SolanaShred,
+        expected_shred1_merkle_root: &'a Hash,
         shred2: &'a SolanaShred,
+        expected_shred2_merkle_root: &'a Hash,
     ) -> (DuplicateBlockProofData<'a>, DuplicateBlockProofContext<'a>) {
-        // Hack to simulate the merkle roots being stored in instruction data
-        let expected_shred1_merkle_root =
-            unsafe { &*Box::into_raw(Box::new(shred1.merkle_root().unwrap_or_default())) };
-        let expected_shred2_merkle_root =
-            unsafe { &*Box::into_raw(Box::new(shred2.merkle_root().unwrap_or_default())) };
         let context = DuplicateBlockProofContext {
             expected_pubkey: leader,
             expected_shred1_merkle_root,
@@ -509,7 +506,10 @@ mod tests {
             (data_shred.clone(), legacy_coding_shred.clone()),
         ];
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = Hash::default();
+            let shred2_mr = Hash::default();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -569,7 +569,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -590,7 +593,10 @@ mod tests {
             new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true, true);
         let shred2 =
             new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true, true);
-        let (proof_data, context) = generate_proof_data(&leader_pubkey, &shred1, &shred2);
+        let shred1_mr = shred1.merkle_root().unwrap();
+        let shred2_mr = shred2.merkle_root().unwrap();
+        let (proof_data, context) =
+            generate_proof_data(&leader_pubkey, &shred1, &shred1_mr, &shred2, &shred2_mr);
         proof_data
             .verify_proof(context, SLOT, &leader_pubkey)
             .unwrap();
@@ -615,7 +621,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.into_iter() {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, &shred1, &shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, &shred1, &shred1_mr, &shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -662,7 +671,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             proof_data
                 .verify_proof(context, SLOT, &leader_pubkey)
                 .unwrap();
@@ -707,7 +719,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -752,7 +767,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             proof_data
                 .verify_proof(context, SLOT, &leader_pubkey)
                 .unwrap();
@@ -814,7 +832,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -844,7 +865,10 @@ mod tests {
             (coding_shreds[0].clone(), coding_shreds_smaller[1].clone()),
         ];
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             proof_data
                 .verify_proof(context, SLOT, &leader_pubkey)
                 .unwrap();
@@ -901,7 +925,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -950,7 +977,10 @@ mod tests {
         ];
 
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -1003,7 +1033,10 @@ mod tests {
             (coding_shred, coding_shred_different_retransmitter),
         ];
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -1047,7 +1080,10 @@ mod tests {
             ),
         ];
         for (shred1, shred2) in test_cases.iter().flat_map(|(a, b)| [(a, b), (b, a)]) {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             proof_data
                 .verify_proof(context, SLOT, &leader_pubkey)
                 .unwrap();
@@ -1110,7 +1146,10 @@ mod tests {
             .iter()
             .flat_map(|(a, b, c)| [(a, b, c), (b, a, c)])
         {
-            let (proof_data, context) = generate_proof_data(&leader_pubkey, shred1, shred2);
+            let shred1_mr = shred1.merkle_root().unwrap();
+            let shred2_mr = shred2.merkle_root().unwrap();
+            let (proof_data, context) =
+                generate_proof_data(&leader_pubkey, shred1, &shred1_mr, shred2, &shred2_mr);
             assert_eq!(
                 proof_data
                     .verify_proof(context, SLOT, &leader_pubkey)
@@ -1132,7 +1171,10 @@ mod tests {
         let shred2 =
             new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true, true);
 
-        let (proof_data, context) = generate_proof_data(&leader_pubkey, &shred1, &shred2);
+        let shred1_mr = shred1.merkle_root().unwrap();
+        let shred2_mr = shred2.merkle_root().unwrap();
+        let (proof_data, context) =
+            generate_proof_data(&leader_pubkey, &shred1, &shred1_mr, &shred2, &shred2_mr);
         proof_data
             .verify_proof(context, SLOT, &leader_pubkey)
             .unwrap();

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -41,13 +41,21 @@ pub enum SlashingError {
     #[error("Invalid shred version")]
     InvalidShredVersion,
 
-    /// Invalid signature on duplicate block proof shreds
-    #[error("Invalid signature")]
-    InvalidSignature,
+    /// Invalid signature verification instruction
+    #[error("Signature verification instruction is invalid")]
+    InvalidSignatureVerification,
 
     /// Legacy shreds are not supported
     #[error("Legacy shreds are not eligible for slashing")]
     LegacyShreds,
+
+    /// Missing instructions sysvar
+    #[error("Instructions sysvar is missing")]
+    MissingInstructionsSysvar,
+
+    /// Missing signature verification instruction
+    #[error("Signature verification instruction is missing")]
+    MissingSignatureVerification,
 
     /// Unable to deserialize proof buffer
     #[error("Proof buffer deserialization error")]
@@ -64,6 +72,10 @@ pub enum SlashingError {
     /// Invalid shred type on duplicate block proof shreds
     #[error("Shred type mismatch")]
     ShredTypeMismatch,
+
+    /// Signature verification instruction did not match the shred
+    #[error("Mismatch between signature verification and shred")]
+    SignatureVerificationMismatch,
 
     /// Invalid slot on duplicate block proof shreds
     #[error("Slot mismatch")]

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -133,24 +133,19 @@ pub fn duplicate_block_proof(
 /// `sigverify_data` should equal the `(shredx.merkle_root, shredx.signature)`
 /// specified in the proof account
 ///
-/// `slashing_instruction_index` should be set to the instruction index of the
-/// slashing instruction in the final transaction. By default this will be `1`,
-/// if you are only sending the results of this function in the transaction.
-///
 /// Returns two instructions, the sigverify and the slashing instruction. These
-/// must be sent consecutively in a transaction with the same ordering to
-/// function properly.
+/// must be sent consecutively as the first two instructions in a transaction
+/// with the same ordering to function properly.
 pub fn duplicate_block_proof_with_sigverify(
     proof_account: &Pubkey,
     instruction_data: &DuplicateBlockProofInstructionData,
-    slashing_instruction_index: u16,
 ) -> [Instruction; 2] {
     let slashing_ix = duplicate_block_proof(proof_account, instruction_data);
-    let signature_instruction_index = slashing_instruction_index;
+    let signature_instruction_index = 1;
     let public_key_offset = DuplicateBlockProofInstructionData::NODE_PUBKEY_OFFSET;
-    let public_key_instruction_index = slashing_instruction_index;
+    let public_key_instruction_index = 1;
     let message_data_size = HASH_BYTES as u16;
-    let message_instruction_index = slashing_instruction_index;
+    let message_instruction_index = 1;
 
     let shred1_sigverify_offset = Ed25519SignatureOffsets {
         signature_offset: DuplicateBlockProofInstructionData::SIGNATURE_1_OFFSET,
@@ -200,7 +195,7 @@ pub(crate) fn construct_instructions_and_sysvar(
     }
 
     let instructions =
-        duplicate_block_proof_with_sigverify(&Pubkey::new_unique(), instruction_data, 1);
+        duplicate_block_proof_with_sigverify(&Pubkey::new_unique(), instruction_data);
     let borrowed_instructions: Vec<BorrowedInstruction> =
         instructions.iter().map(borrow_instruction).collect();
     let mut instructions_sysvar_data =

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -105,11 +105,10 @@ pub(crate) fn decode_instruction_type(input: &[u8]) -> Result<SlashingInstructio
 
 /// Utility function for decoding instruction data
 pub(crate) fn decode_instruction_data<T: Pod>(input_with_type: &[u8]) -> Result<&T, ProgramError> {
-    let data_len = pod_get_packed_len::<T>().saturating_add(1);
-    if input_with_type.len() != data_len {
+    if input_with_type.len() != pod_get_packed_len::<T>().saturating_add(1) {
         Err(ProgramError::InvalidInstructionData)
     } else {
-        pod_from_bytes(&input_with_type[1..data_len])
+        pod_from_bytes(&input_with_type[1..])
     }
 }
 

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod instruction;
 pub mod processor;
 mod shred;
+mod sigverify;
 pub mod state;
 
 // Export current SDK types for downstream users building with a different SDK

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -19,9 +19,16 @@ use {
         pubkey::Pubkey,
         sysvar::{clock::Clock, epoch_schedule::EpochSchedule, Sysvar},
     },
+    std::slice::Iter,
 };
 
-fn verify_proof_data<'a, T>(slot: Slot, pubkey: &Pubkey, proof_data: &'a [u8]) -> ProgramResult
+fn verify_proof_data<'a, 'b, T>(
+    slot: Slot,
+    pubkey: &Pubkey,
+    proof_data: &'a [u8],
+    instruction_data: &'a [u8],
+    accounts_info_iter: &'a mut Iter<'_, AccountInfo<'b>>,
+) -> ProgramResult
 where
     T: SlashingProofData<'a>,
 {
@@ -35,10 +42,9 @@ where
         return Err(SlashingError::ExceedsStatueOfLimitations.into());
     }
 
-    let proof_data: T =
-        T::unpack(proof_data).map_err(|_| SlashingError::ShredDeserializationError)?;
+    let (proof_data, context) = T::unpack(proof_data, instruction_data, accounts_info_iter)?;
 
-    SlashingProofData::verify_proof(proof_data, slot, pubkey)?;
+    SlashingProofData::verify_proof(proof_data, context, slot, pubkey)?;
 
     // TODO: follow up PR will record this violation in context state account. just
     // log for now.
@@ -58,16 +64,18 @@ pub fn process_instruction(
 ) -> ProgramResult {
     let instruction_type = decode_instruction_type(input)?;
     let account_info_iter = &mut accounts.iter();
-    let proof_data_info = next_account_info(account_info_iter);
+    let proof_data_info = next_account_info(account_info_iter)?;
 
     match instruction_type {
         SlashingInstruction::DuplicateBlockProof => {
             let data = decode_instruction_data::<DuplicateBlockProofInstructionData>(input)?;
-            let proof_data = &proof_data_info?.data.borrow()[u64::from(data.offset) as usize..];
+            let proof_data = &proof_data_info.data.borrow()[u64::from(data.offset) as usize..];
             verify_proof_data::<DuplicateBlockProofData>(
                 data.slot.into(),
                 &data.node_pubkey,
                 proof_data,
+                input,
+                account_info_iter,
             )?;
             Ok(())
         }
@@ -79,17 +87,21 @@ mod tests {
     use {
         super::verify_proof_data,
         crate::{
-            duplicate_block_proof::DuplicateBlockProofData, error::SlashingError,
+            duplicate_block_proof::DuplicateBlockProofData,
+            error::SlashingError,
+            instruction::{construct_instructions_and_sysvar, DuplicateBlockProofSigverifyData},
             shred::tests::new_rand_data_shred,
         },
         rand::Rng,
         solana_ledger::shred::Shredder,
         solana_sdk::{
+            account_info::AccountInfo,
             clock::{Clock, Slot, DEFAULT_SLOTS_PER_EPOCH},
             epoch_schedule::EpochSchedule,
             program_error::ProgramError,
             signature::Keypair,
             signer::Signer,
+            sysvar::instructions::{self},
         },
         std::sync::{Arc, RwLock},
     };
@@ -99,7 +111,7 @@ mod tests {
         static ref CLOCK_SLOT: Arc<RwLock<Slot>> = Arc::new(RwLock::new(SLOT));
     }
 
-    fn generate_proof_data(leader: Arc<Keypair>) -> Vec<u8> {
+    fn generate_proof_data(leader: Arc<Keypair>) -> (DuplicateBlockProofSigverifyData, Vec<u8>) {
         let mut rng = rand::thread_rng();
         let (slot, parent_slot, reference_tick, version) = (SLOT, SLOT - 1, 0, 0);
         let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
@@ -108,11 +120,17 @@ mod tests {
             new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true, true);
         let shred2 =
             new_rand_data_shred(&mut rng, next_shred_index, &shredder, &leader, true, true);
-        let proof = DuplicateBlockProofData {
+        let sigverify_data = DuplicateBlockProofSigverifyData {
+            shred_1_merkle_root: shred1.merkle_root().unwrap(),
+            shred_2_merkle_root: shred2.merkle_root().unwrap(),
+            shred_1_signature: shred1.signature().as_ref().try_into().unwrap(),
+            shred_2_signature: shred2.signature().as_ref().try_into().unwrap(),
+        };
+        let proof_data = DuplicateBlockProofData {
             shred1: shred1.payload().as_slice(),
             shred2: shred2.payload().as_slice(),
         };
-        proof.pack()
+        (sigverify_data, proof_data.pack())
     }
 
     #[test]
@@ -157,10 +175,27 @@ mod tests {
 
         solana_sdk::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
         let leader = Arc::new(Keypair::new());
+        let (sigverify_data, proof_data) = generate_proof_data(leader.clone());
+        let mut lamports = 0;
+        let (instructions, mut instructions_sysvar_data) =
+            construct_instructions_and_sysvar(leader.pubkey(), SLOT, &sigverify_data);
+        let instructions_sysvar_account = AccountInfo::new(
+            &instructions::ID,
+            false,
+            true,
+            &mut lamports,
+            &mut instructions_sysvar_data,
+            &instructions::ID,
+            false,
+            0,
+        );
+
         verify_proof_data::<DuplicateBlockProofData>(
             SLOT,
             &leader.pubkey(),
-            &generate_proof_data(leader),
+            &proof_data,
+            &instructions[1].data,
+            &mut [instructions_sysvar_account].iter(),
         )
     }
 }

--- a/program/src/sigverify.rs
+++ b/program/src/sigverify.rs
@@ -124,7 +124,12 @@ impl<'a> SignatureVerification<'a> {
         if sigverify_ix.program_id != ed25519_program::id() {
             return Err(SlashingError::MissingSignatureVerification);
         }
-        if sigverify_ix.data[0] < NUM_VERIFICATIONS as u8 {
+        let num_signatures = u16::from_le_bytes(
+            sigverify_ix.data[0..2]
+                .try_into()
+                .map_err(|_| SlashingError::MissingSignatureVerification)?,
+        );
+        if num_signatures < NUM_VERIFICATIONS as u16 {
             return Err(SlashingError::MissingSignatureVerification);
         }
         let expected_data_size = NUM_VERIFICATIONS

--- a/program/src/sigverify.rs
+++ b/program/src/sigverify.rs
@@ -1,0 +1,185 @@
+//! Parsing signature verification results through instruction introspection
+use {
+    crate::error::SlashingError,
+    arrayvec::ArrayVec,
+    bytemuck::{Pod, Zeroable},
+    solana_program::{
+        account_info::AccountInfo,
+        ed25519_program,
+        instruction::Instruction,
+        msg,
+        pubkey::{Pubkey, PUBKEY_BYTES},
+        sysvar::instructions::{get_instruction_relative, load_current_index_checked},
+    },
+    solana_signature::SIGNATURE_BYTES,
+};
+
+const SIGNATURE_OFFSETS_SERIALIZED_SIZE: usize = 14;
+const SIGNATURE_OFFSETS_START: usize = 2;
+
+#[derive(Default, Debug, Copy, Clone, Zeroable, Pod, Eq, PartialEq)]
+#[repr(C)]
+pub(crate) struct Ed25519SignatureOffsets {
+    pub(crate) signature_offset: u16, // offset to ed25519 signature of 64 bytes
+    pub(crate) signature_instruction_index: u16, // instruction index to find signature
+    pub(crate) public_key_offset: u16, // offset to public key of 32 bytes
+    pub(crate) public_key_instruction_index: u16, // instruction index to find public key
+    pub(crate) message_data_offset: u16, // offset to start of message data
+    pub(crate) message_data_size: u16, // size of message data
+    pub(crate) message_instruction_index: u16, // index of instruction data to get message data
+}
+
+impl Ed25519SignatureOffsets {
+    pub(crate) fn to_instruction(offsets: &[Self]) -> Instruction {
+        let mut instruction_data = Vec::with_capacity(
+            SIGNATURE_OFFSETS_START
+                .saturating_add(SIGNATURE_OFFSETS_SERIALIZED_SIZE.saturating_mul(offsets.len())),
+        );
+
+        let num_signatures: u8 = offsets.len() as u8;
+
+        // add padding byte so that offset structure is aligned
+        instruction_data.extend_from_slice(bytemuck::bytes_of(&[num_signatures, 0]));
+
+        for offsets in offsets {
+            instruction_data.extend_from_slice(bytemuck::bytes_of(offsets));
+        }
+
+        Instruction {
+            program_id: ed25519_program::id(),
+            accounts: vec![],
+            data: instruction_data,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SignatureVerification<'a> {
+    pub(crate) pubkey: &'a Pubkey,
+    pub(crate) message: &'a [u8],
+    pub(crate) signature: &'a [u8; SIGNATURE_BYTES],
+}
+
+impl<'a> SignatureVerification<'a> {
+    fn new(
+        pubkey: &'a [u8],
+        message: &'a [u8],
+        signature: &'a [u8],
+    ) -> Result<SignatureVerification<'a>, SlashingError> {
+        let pubkey: &'a Pubkey = bytemuck::try_from_bytes(pubkey).map_err(|_| {
+            msg!("Failed to deserialize pubkey");
+            SlashingError::InvalidSignatureVerification
+        })?;
+
+        let signature: &'a [u8; SIGNATURE_BYTES] = signature.try_into().map_err(|_| {
+            msg!("Failed to deserialize signature");
+            SlashingError::InvalidSignatureVerification
+        })?;
+
+        Ok(Self {
+            pubkey,
+            message,
+            signature,
+        })
+    }
+
+    fn get_data_slice<'b>(
+        data: &'a [u8],
+        _instructions_sysvar: &'a AccountInfo<'b>,
+        instruction_index: u16,
+        current_index: u16,
+        offset_start: u16,
+        size: usize,
+    ) -> Result<&'a [u8], SlashingError> {
+        if instruction_index != current_index {
+            // For duplicate block slashing the message is small enough to fit inside the
+            // slashing instruction but this might not be the case for future slashing cases
+            // TODO: re-implement load_instruction_at_checked(instruction_index as usize,
+            // instructions_sysvar) in a zero copy way.
+            msg!("Signature verification instruction must store the data within the slashing instruction");
+            return Err(SlashingError::InvalidSignatureVerification);
+        }
+        let start = offset_start as usize;
+        let end = start.saturating_add(size);
+        if end > data.len() {
+            return Err(SlashingError::InvalidSignatureVerification);
+        }
+
+        Ok(&data[start..end])
+    }
+
+    /// Perform instruction introspection to grab details about signature
+    /// verification
+    pub(crate) fn inspect_verifications<'b, const NUM_VERIFICATIONS: usize>(
+        instruction_data: &'a [u8],
+        instructions_sysvar: &'a AccountInfo<'b>,
+        relative_index: i64,
+    ) -> Result<[SignatureVerification<'a>; NUM_VERIFICATIONS], SlashingError> {
+        let mut verifications = ArrayVec::<SignatureVerification<'a>, NUM_VERIFICATIONS>::new();
+
+        // Instruction inspection to unpack successful signature verifications
+        let current_index = load_current_index_checked(instructions_sysvar)
+            .map_err(|_| SlashingError::InvalidSignatureVerification)?;
+        let sigverify_ix = get_instruction_relative(relative_index, instructions_sysvar)
+            .map_err(|_| SlashingError::MissingSignatureVerification)?;
+        if sigverify_ix.program_id != ed25519_program::id() {
+            return Err(SlashingError::MissingSignatureVerification);
+        }
+        if sigverify_ix.data[0] < NUM_VERIFICATIONS as u8 {
+            return Err(SlashingError::MissingSignatureVerification);
+        }
+        let expected_data_size = NUM_VERIFICATIONS
+            .saturating_mul(SIGNATURE_OFFSETS_SERIALIZED_SIZE)
+            .saturating_add(SIGNATURE_OFFSETS_START);
+        if sigverify_ix.data.len() < expected_data_size {
+            return Err(SlashingError::InvalidSignatureVerification);
+        }
+
+        for i in 0..NUM_VERIFICATIONS {
+            let start = i
+                .saturating_mul(SIGNATURE_OFFSETS_SERIALIZED_SIZE)
+                .saturating_add(SIGNATURE_OFFSETS_START);
+            let end = start.saturating_add(SIGNATURE_OFFSETS_SERIALIZED_SIZE);
+
+            let offsets: &Ed25519SignatureOffsets =
+                bytemuck::try_from_bytes(&sigverify_ix.data[start..end])
+                    .map_err(|_| SlashingError::InvalidSignatureVerification)?;
+
+            // Parse out signature
+            let signature = Self::get_data_slice(
+                instruction_data,
+                instructions_sysvar,
+                offsets.signature_instruction_index,
+                current_index,
+                offsets.signature_offset,
+                SIGNATURE_BYTES,
+            )?;
+
+            // Parse out pubkey
+            let pubkey = Self::get_data_slice(
+                instruction_data,
+                instructions_sysvar,
+                offsets.public_key_instruction_index,
+                current_index,
+                offsets.public_key_offset,
+                PUBKEY_BYTES,
+            )?;
+
+            // Parse out message
+            let message = Self::get_data_slice(
+                instruction_data,
+                instructions_sysvar,
+                offsets.message_instruction_index,
+                current_index,
+                offsets.message_data_offset,
+                offsets.message_data_size as usize,
+            )?;
+
+            verifications.push(SignatureVerification::new(pubkey, message, signature)?);
+        }
+        verifications
+            .into_inner()
+            .map_err(|_| SlashingError::InvalidSignatureVerification)
+    }
+}

--- a/program/src/sigverify.rs
+++ b/program/src/sigverify.rs
@@ -36,10 +36,8 @@ impl Ed25519SignatureOffsets {
                 .saturating_add(SIGNATURE_OFFSETS_SERIALIZED_SIZE.saturating_mul(offsets.len())),
         );
 
-        let num_signatures: u8 = offsets.len() as u8;
-
-        // add padding byte so that offset structure is aligned
-        instruction_data.extend_from_slice(bytemuck::bytes_of(&[num_signatures, 0]));
+        let num_signatures = offsets.len() as u16;
+        instruction_data.extend_from_slice(&num_signatures.to_le_bytes());
 
         for offsets in offsets {
             instruction_data.extend_from_slice(bytemuck::bytes_of(offsets));

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -31,7 +31,7 @@ use {
         processor::process_instruction,
         state::ProofType,
     },
-    std::sync::Arc,
+    std::{assert_ne, sync::Arc},
 };
 
 const SLOT: Slot = 53084024;
@@ -273,6 +273,12 @@ async fn valid_proof_coding() {
         new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[0].clone();
     let shred2 =
         new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[1].clone();
+
+    assert_ne!(
+        shred1.merkle_root().unwrap(),
+        shred2.merkle_root().unwrap(),
+        "Expected merkle root failure"
+    );
 
     let duplicate_proof = DuplicateBlockProofData {
         shred1: shred1.payload().as_slice(),

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -12,18 +12,24 @@ use {
     solana_sdk::{
         clock::{Clock, Slot},
         decode_error::DecodeError,
-        hash::Hash,
-        instruction::InstructionError,
+        ed25519_instruction::SIGNATURE_OFFSETS_START,
+        hash::{Hash, HASH_BYTES},
+        instruction::{Instruction, InstructionError},
         rent::Rent,
         signature::{Keypair, Signer},
         system_instruction, system_transaction,
         transaction::{Transaction, TransactionError},
     },
+    solana_signature::SIGNATURE_BYTES,
     spl_pod::bytemuck::pod_get_packed_len,
     spl_record::{instruction as record, state::RecordData},
     spl_slashing::{
-        duplicate_block_proof::DuplicateBlockProofData, error::SlashingError, id, instruction,
-        processor::process_instruction, state::ProofType,
+        duplicate_block_proof::DuplicateBlockProofData,
+        error::SlashingError,
+        id,
+        instruction::{duplicate_block_proof_with_sigverify, DuplicateBlockProofSigverifyData},
+        processor::process_instruction,
+        state::ProofType,
     },
     std::sync::Arc,
 };
@@ -109,6 +115,29 @@ async fn write_proof(
 
         offset = offset.checked_add(chunk_size).unwrap();
     }
+}
+
+fn slashing_instructions(
+    proof_account: &Pubkey,
+    slot: Slot,
+    node_pubkey: Pubkey,
+    shred1: &Shred,
+    shred2: &Shred,
+) -> [Instruction; 2] {
+    let sigverify_data = DuplicateBlockProofSigverifyData {
+        shred_1_merkle_root: shred1.merkle_root().unwrap(),
+        shred_1_signature: (*shred1.signature()).into(),
+        shred_2_merkle_root: shred2.merkle_root().unwrap(),
+        shred_2_signature: (*shred2.signature()).into(),
+    };
+    duplicate_block_proof_with_sigverify(
+        proof_account,
+        RecordData::WRITABLE_START_INDEX as u64,
+        slot,
+        node_pubkey,
+        &sigverify_data,
+        1,
+    )
 }
 
 pub fn new_rand_data_shred<R: Rng>(
@@ -219,12 +248,7 @@ async fn valid_proof_data() {
     write_proof(&mut context, &authority, &account, &data).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::duplicate_block_proof(
-            &account.pubkey(),
-            RecordData::WRITABLE_START_INDEX as u64,
-            slot,
-            leader.pubkey(),
-        )],
+        &slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2),
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -254,11 +278,6 @@ async fn valid_proof_coding() {
     let shred2 =
         new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[1].clone();
 
-    assert!(
-        ErasureMeta::check_erasure_consistency(&shred1, &shred2),
-        "Expected erasure consistency failure",
-    );
-
     let duplicate_proof = DuplicateBlockProofData {
         shred1: shred1.payload().as_slice(),
         shred2: shred2.payload().as_slice(),
@@ -269,12 +288,7 @@ async fn valid_proof_coding() {
     write_proof(&mut context, &authority, &account, &data).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::duplicate_block_proof(
-            &account.pubkey(),
-            RecordData::WRITABLE_START_INDEX as u64,
-            slot,
-            leader.pubkey(),
-        )],
+        &slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2),
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -312,12 +326,7 @@ async fn invalid_proof_data() {
     write_proof(&mut context, &authority, &account, &data).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::duplicate_block_proof(
-            &account.pubkey(),
-            RecordData::WRITABLE_START_INDEX as u64,
-            slot,
-            leader.pubkey(),
-        )],
+        &slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2),
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -328,7 +337,7 @@ async fn invalid_proof_data() {
         .await
         .unwrap_err()
         .unwrap();
-    let TransactionError::InstructionError(0, InstructionError::Custom(code)) = err else {
+    let TransactionError::InstructionError(1, InstructionError::Custom(code)) = err else {
         panic!("Invalid error {err:?}");
     };
     let err: SlashingError = SlashingError::decode_custom_error_to_enum(code).unwrap();
@@ -366,12 +375,59 @@ async fn invalid_proof_coding() {
     write_proof(&mut context, &authority, &account, &data).await;
 
     let transaction = Transaction::new_signed_with_payer(
-        &[instruction::duplicate_block_proof(
-            &account.pubkey(),
-            RecordData::WRITABLE_START_INDEX as u64,
-            slot,
-            leader.pubkey(),
-        )],
+        &slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2),
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    let TransactionError::InstructionError(1, InstructionError::Custom(code)) = err else {
+        panic!("Invalid error {err:?}");
+    };
+    let err: SlashingError = SlashingError::decode_custom_error_to_enum(code).unwrap();
+    assert_eq!(err, SlashingError::InvalidErasureMetaConflict);
+}
+
+#[tokio::test]
+async fn missing_sigverify() {
+    let mut context = program_test().start_with_context().await;
+    setup_clock(&mut context).await;
+
+    let authority = Keypair::new();
+    let account = Keypair::new();
+
+    let mut rng = rand::thread_rng();
+    let leader = Arc::new(Keypair::new());
+    let (slot, parent_slot, reference_tick, version) = (SLOT, 53084023, 0, 0);
+    let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
+    let next_shred_index = rng.gen_range(0..32_000);
+    let shred1 =
+        new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[0].clone();
+    let shred2 =
+        new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[1].clone();
+
+    let duplicate_proof = DuplicateBlockProofData {
+        shred1: shred1.payload().as_slice(),
+        shred2: shred2.payload().as_slice(),
+    };
+    let data = duplicate_proof.pack();
+
+    initialize_duplicate_proof_account(&mut context, &authority, &account).await;
+    write_proof(&mut context, &authority, &account, &data).await;
+    // Remove the sigverify
+    let instructions =
+        [
+            slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2)[1]
+                .clone(),
+        ];
+
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
         Some(&context.payer.pubkey()),
         &[&context.payer],
         context.last_blockhash,
@@ -386,5 +442,113 @@ async fn invalid_proof_coding() {
         panic!("Invalid error {err:?}");
     };
     let err: SlashingError = SlashingError::decode_custom_error_to_enum(code).unwrap();
-    assert_eq!(err, SlashingError::InvalidErasureMetaConflict);
+    assert_eq!(err, SlashingError::MissingSignatureVerification);
+
+    // Only sigverify one of the shreds
+    let mut instructions =
+        slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2);
+    instructions[0].data[0] = 1;
+
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    let TransactionError::InstructionError(1, InstructionError::Custom(code)) = err else {
+        panic!("Invalid error {err:?}");
+    };
+    let err: SlashingError = SlashingError::decode_custom_error_to_enum(code).unwrap();
+    assert_eq!(err, SlashingError::MissingSignatureVerification);
+}
+
+#[tokio::test]
+async fn improper_sigverify() {
+    let mut context = program_test().start_with_context().await;
+    setup_clock(&mut context).await;
+
+    let authority = Keypair::new();
+    let account = Keypair::new();
+
+    let mut rng = rand::thread_rng();
+    let leader = Arc::new(Keypair::new());
+    let (slot, parent_slot, reference_tick, version) = (SLOT, 53084023, 0, 0);
+    let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
+    let next_shred_index = rng.gen_range(0..32_000);
+    let shred1 =
+        new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[0].clone();
+    let shred2 =
+        new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[1].clone();
+
+    let duplicate_proof = DuplicateBlockProofData {
+        shred1: shred1.payload().as_slice(),
+        shred2: shred2.payload().as_slice(),
+    };
+    let data = duplicate_proof.pack();
+
+    initialize_duplicate_proof_account(&mut context, &authority, &account).await;
+    write_proof(&mut context, &authority, &account, &data).await;
+
+    // Replace one of the signature verifications with a random message instead
+    let message = Hash::new_unique().to_bytes();
+    let signature = <[u8; SIGNATURE_BYTES]>::from(leader.sign_message(&message));
+    let mut instructions =
+        slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2);
+    const MESSAGE_START: usize = 1 + 8 + 8 + 32;
+    const SIGNATURE_START: usize = MESSAGE_START + HASH_BYTES;
+    instructions[1].data[MESSAGE_START..SIGNATURE_START].copy_from_slice(&message);
+    instructions[1].data[SIGNATURE_START..SIGNATURE_START + SIGNATURE_BYTES]
+        .copy_from_slice(&signature);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    let TransactionError::InstructionError(1, InstructionError::Custom(code)) = err else {
+        panic!("Invalid error {err:?}");
+    };
+    let err: SlashingError = SlashingError::decode_custom_error_to_enum(code).unwrap();
+    assert_eq!(err, SlashingError::SignatureVerificationMismatch);
+
+    // Put the sigverify data in the sigverify instruction (not allowed currently)
+    let mut instructions =
+        slashing_instructions(&account.pubkey(), slot, leader.pubkey(), &shred1, &shred2);
+    instructions[0].data[SIGNATURE_OFFSETS_START..SIGNATURE_OFFSETS_START + 2]
+        .copy_from_slice(&100u16.to_le_bytes());
+    instructions[0].data[SIGNATURE_OFFSETS_START + 2..SIGNATURE_OFFSETS_START + 4]
+        .copy_from_slice(&0u16.to_le_bytes());
+    instructions[0].data.extend_from_slice(&[0; 200]);
+    instructions[0].data[100..100 + SIGNATURE_BYTES]
+        .copy_from_slice(&<[u8; SIGNATURE_BYTES]>::from(*shred1.signature()));
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    let err = context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err()
+        .unwrap();
+    let TransactionError::InstructionError(1, InstructionError::Custom(code)) = err else {
+        panic!("Invalid error {err:?}");
+    };
+    let err: SlashingError = SlashingError::decode_custom_error_to_enum(code).unwrap();
+    assert_eq!(err, SlashingError::InvalidSignatureVerification);
 }

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -133,7 +133,7 @@ fn slashing_instructions(
         shred_2_merkle_root: shred2.merkle_root().unwrap(),
         shred_2_signature: (*shred2.signature()).into(),
     };
-    duplicate_block_proof_with_sigverify(proof_account, &instruction_data, 1)
+    duplicate_block_proof_with_sigverify(proof_account, &instruction_data)
 }
 
 pub fn new_rand_data_shred<R: Rng>(

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -52,3 +52,4 @@ slashable
 merkle
 retransmitter/SM
 FEC
+sigverify


### PR DESCRIPTION
Adds signature verification of the shreds included in a duplicate block proof to the slashing program.
Due to the limitations of zerocopying from the instructions sysvar the requirements are as follows:
- The signature verification instruction to the Ed25519 program must be in the index immediately before the Slashing instruction
- This instruction must specify 2 verifications, the first one for `shred1` and the second for `shred2` as indicated by the ordering in the `proof_account` specified to the slashing instruciton
- The `(pubkey, message, signature)` data indicated by the Ed25519 ix's offsets *must be* in the instruction data for the slashing instruction. 

If each  `(pubkey, message, signature)` matches the `(node_pubkey, shredx.merkle_root, shredx.signature)` for both shreds, then the signature verification is considered successful.

Additionally we expose a utility for the user to create both the sigverify instruction and the slashing instruction together.

Will update the SIMD if this approach is satisfactory