### PR TITLE
patches code accessing shred payload as slice

### DIFF
--- a/program/src/duplicate_block_proof.rs
+++ b/program/src/duplicate_block_proof.rs
@@ -421,8 +421,8 @@ mod tests {
         };
         (
             DuplicateBlockProofData {
-                shred1: shred1.payload().as_slice(),
-                shred2: shred2.payload().as_slice(),
+                shred1: shred1.payload().as_ref(),
+                shred2: shred2.payload().as_ref(),
             },
             context,
         )

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -131,8 +131,8 @@ mod tests {
             shred_2_signature: shred2.signature().as_ref().try_into().unwrap(),
         };
         let proof_data = DuplicateBlockProofData {
-            shred1: shred1.payload().as_slice(),
-            shred2: shred2.payload().as_slice(),
+            shred1: shred1.payload().as_ref(),
+            shred2: shred2.payload().as_ref(),
         };
         (sigverify_data, proof_data.pack())
     }

--- a/program/src/shred.rs
+++ b/program/src/shred.rs
@@ -533,7 +533,7 @@ pub(crate) mod tests {
                 .into_iter()
                 .chain(coding_solana_shreds.into_iter())
             {
-                let payload = solana_shred.payload().as_slice();
+                let payload = solana_shred.payload().as_ref();
                 let shred = Shred::new_from_payload(payload).unwrap();
 
                 assert_eq!(shred.slot().unwrap(), solana_shred.slot());

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -235,8 +235,8 @@ async fn valid_proof_data() {
     );
 
     let duplicate_proof = DuplicateBlockProofData {
-        shred1: shred1.payload().as_slice(),
-        shred2: shred2.payload().as_slice(),
+        shred1: shred1.payload().as_ref(),
+        shred2: shred2.payload().as_ref(),
     };
     let data = duplicate_proof.pack();
 
@@ -281,8 +281,8 @@ async fn valid_proof_coding() {
     );
 
     let duplicate_proof = DuplicateBlockProofData {
-        shred1: shred1.payload().as_slice(),
-        shred2: shred2.payload().as_slice(),
+        shred1: shred1.payload().as_ref(),
+        shred2: shred2.payload().as_ref(),
     };
     let data = duplicate_proof.pack();
 
@@ -319,8 +319,8 @@ async fn invalid_proof_data() {
     let shred2 = shred1.clone();
 
     let duplicate_proof = DuplicateBlockProofData {
-        shred1: shred1.payload().as_slice(),
-        shred2: shred2.payload().as_slice(),
+        shred1: shred1.payload().as_ref(),
+        shred2: shred2.payload().as_ref(),
     };
     let data = duplicate_proof.pack();
 
@@ -368,8 +368,8 @@ async fn invalid_proof_coding() {
         "Expecting no erasure conflict"
     );
     let duplicate_proof = DuplicateBlockProofData {
-        shred1: shred1.payload().as_slice(),
-        shred2: shred2.payload().as_slice(),
+        shred1: shred1.payload().as_ref(),
+        shred2: shred2.payload().as_ref(),
     };
     let data = duplicate_proof.pack();
 
@@ -414,8 +414,8 @@ async fn missing_sigverify() {
         new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[1].clone();
 
     let duplicate_proof = DuplicateBlockProofData {
-        shred1: shred1.payload().as_slice(),
-        shred2: shred2.payload().as_slice(),
+        shred1: shred1.payload().as_ref(),
+        shred2: shred2.payload().as_ref(),
     };
     let data = duplicate_proof.pack();
 
@@ -489,8 +489,8 @@ async fn improper_sigverify() {
         new_rand_coding_shreds(&mut rng, next_shred_index, 10, &shredder, &leader)[1].clone();
 
     let duplicate_proof = DuplicateBlockProofData {
-        shred1: shred1.payload().as_slice(),
-        shred2: shred2.payload().as_slice(),
+        shred1: shred1.payload().as_ref(),
+        shred2: shred2.payload().as_ref(),
     };
     let data = duplicate_proof.pack();
 


### PR DESCRIPTION
https://github.com/anza-xyz/agave/pull/4690 encapsulates the type of shred payload, and this code should use

    shred.payload().as_ref()

instead of

    shred.payload().as_slice()