### PR TITLE
lockfile: Update for improper versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7677,7 +7677,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem

The lockfile currently doesn't work because it specifies bitflags v2.7.0, but there's no declaration for it elsewhere.

#### Summary of changes

Run `cargo tree` and commit it