### PR TITLE
use realloc instead of CPI when creating the report account

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -254,17 +254,6 @@ where
         return Err(ProgramError::from(SlashingError::ReportAccountNotPrefunded));
     }
 
-    // Allocate enough space for the report
-    let allocate_instruction = system_instruction::allocate(&pda, data_len as u64);
-    invoke_signed(
-        &allocate_instruction,
-        &[
-            accounts.violation_pda_account.clone(),
-            accounts.system_program_account.clone(),
-        ],
-        &[&seeds],
-    )?;
-
     // Assign the slashing program as the owner
     let assign_instruction = system_instruction::assign(&pda, &id());
     invoke_signed(
@@ -275,6 +264,9 @@ where
         ],
         &[&seeds],
     )?;
+
+    // Allocate enough space for the report
+    accounts.violation_pda_account.realloc(data_len, false)?;
 
     // Verify that the account can now hold the report
     if accounts.violation_pda_account.data_len() != data_len {


### PR DESCRIPTION
By first assigning the account owner to the slashing program via CPI, we can use the `realloc` function on the account directly, avoiding the second CPI into the system program.

CU before:
```
Program S1ashing11111111111111111111111111111111111 consumed 44689 of 599850 compute units
```

CU after:
```
Program S1ashing11111111111111111111111111111111111 consumed 42856 of 599850 compute units
```