### PR TITLE
add instruction to close violation report

### DIFF
--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -9,6 +9,11 @@ use {
 /// Errors that may be returned by the program.
 #[derive(Clone, Copy, Debug, Eq, Error, FromPrimitive, PartialEq)]
 pub enum SlashingError {
+    /// Attempting to close a violation report before 3
+    /// epochs have passed
+    #[error("Closing violation report too soon")]
+    CloseViolationReportTooSoon,
+
     /// Violation has already been reported
     #[error("Duplicate report")]
     DuplicateReport,
@@ -16,6 +21,10 @@ pub enum SlashingError {
     /// Violation is too old for statute of limitations
     #[error("Exceeds statute of limitations")]
     ExceedsStatuteOfLimitations,
+
+    /// Destination account does not match the key on the report
+    #[error("Invalid destination account")]
+    InvalidDestinationAccount,
 
     /// Invalid shred variant
     #[error("Invalid shred variant")]

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -15,7 +15,7 @@ pub mod state;
 pub use solana_program;
 use {
     solana_program::{clock::Slot, pubkey::Pubkey},
-    state::ProofType,
+    state::{ProofType, ViolationReport},
 };
 
 solana_program::declare_id!("S1ashing11111111111111111111111111111111111");
@@ -36,4 +36,52 @@ pub fn get_violation_report_address(
         ],
         &id(),
     )
+}
+
+struct ViolationReportAddress<'a> {
+    address: Pubkey,
+    pubkey_seed: &'a [u8],
+    slot_seed: &'a [u8; 8],
+    violation_seed: [u8; 1],
+    bump_seed: [u8; 1],
+}
+
+impl<'a> ViolationReportAddress<'a> {
+    pub(crate) fn new(report: &'a ViolationReport) -> ViolationReportAddress<'a> {
+        let pubkey_seed = report.pubkey.as_ref();
+        let slot_seed = &report.slot.0;
+        let violation_seed = [report.violation_type];
+        let (pda, bump) =
+            Pubkey::find_program_address(&[pubkey_seed, slot_seed, &violation_seed], &id());
+        let bump_seed = [bump];
+        Self {
+            address: pda,
+            pubkey_seed,
+            slot_seed,
+            violation_seed,
+            bump_seed,
+        }
+    }
+
+    pub(crate) fn key(&self) -> &Pubkey {
+        &self.address
+    }
+
+    pub(crate) fn seeds(&self) -> [&[u8]; 4] {
+        [
+            self.pubkey_seed,
+            self.slot_seed,
+            &self.violation_seed,
+            &self.bump_seed,
+        ]
+    }
+
+    pub(crate) fn seeds_owned(&self) -> [Vec<u8>; 4] {
+        [
+            self.pubkey_seed.to_owned(),
+            Vec::from(self.slot_seed),
+            Vec::from(self.violation_seed),
+            Vec::from(self.bump_seed),
+        ]
+    }
 }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{
+        check_id,
         duplicate_block_proof::DuplicateBlockProofData,
         error::SlashingError,
         instruction::{
@@ -9,16 +10,17 @@ use {
             SlashingInstruction,
         },
         state::{
-            store_violation_report, PodEpoch, ProofType, SlashingAccounts, SlashingProofData,
-            ViolationReport,
+            close_violation_report, store_violation_report, PodEpoch, ProofType, SlashingAccounts,
+            SlashingProofData, ViolationReport,
         },
     },
     solana_program::{
-        account_info::AccountInfo,
+        account_info::{next_account_info, AccountInfo},
         entrypoint::ProgramResult,
         msg,
         program_error::ProgramError,
         pubkey::Pubkey,
+        system_program,
         sysvar::{clock::Clock, epoch_schedule::EpochSchedule, Sysvar},
     },
 };
@@ -65,9 +67,27 @@ pub fn process_instruction(
 ) -> ProgramResult {
     let instruction_type = decode_instruction_type(input)?;
     let account_info_iter = &mut accounts.iter();
-    let accounts = SlashingAccounts::new(account_info_iter)?;
     match instruction_type {
+        SlashingInstruction::CloseViolationReport => {
+            let report_account = next_account_info(account_info_iter)?;
+            let destination_account = next_account_info(account_info_iter)?;
+            let system_program_account = next_account_info(account_info_iter)?;
+
+            if !check_id(report_account.owner) || report_account.data_is_empty() {
+                return Err(ProgramError::from(
+                    SlashingError::InvalidViolationReportAcccount,
+                ));
+            }
+            if !system_program::check_id(system_program_account.key) {
+                return Err(ProgramError::from(
+                    SlashingError::MissingSystemProgramAccount,
+                ));
+            }
+
+            close_violation_report(report_account, destination_account, system_program_account)?;
+        }
         SlashingInstruction::DuplicateBlockProof => {
+            let accounts = SlashingAccounts::new(account_info_iter)?;
             let data = decode_instruction_data::<DuplicateBlockProofInstructionData>(input)?;
             let proof_data = &accounts.proof_account.try_borrow_data()?[data.offset()?..];
             let violation_report = ViolationReport {
@@ -86,9 +106,9 @@ pub fn process_instruction(
                 proof_data,
                 input,
             )?;
-            Ok(())
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,10 +1,13 @@
 //! Program state
 use {
-    crate::{check_id, duplicate_block_proof::DuplicateBlockProofData, error::SlashingError, id},
+    crate::{
+        check_id, duplicate_block_proof::DuplicateBlockProofData, error::SlashingError, id,
+        ViolationReportAddress,
+    },
     bytemuck::{Pod, Zeroable},
     solana_program::{
         account_info::{next_account_info, AccountInfo},
-        clock::Slot,
+        clock::{Epoch, Slot},
         msg,
         program::invoke_signed,
         program_error::ProgramError,
@@ -13,7 +16,7 @@ use {
         system_instruction, system_program,
         sysvar::{self, Sysvar},
     },
-    spl_pod::primitives::PodU64,
+    spl_pod::{bytemuck::pod_from_bytes, primitives::PodU64},
 };
 
 const PACKET_DATA_SIZE: usize = 1232;
@@ -222,16 +225,15 @@ pub(crate) fn store_violation_report<'a, 'b, T>(
 where
     T: SlashingProofData<'a>,
 {
-    let slot = report.slot;
-    let pubkey_seed = report.pubkey.as_ref();
-    let slot_seed = slot.0;
-    let violation_seed = [report.violation_type];
-    let mut seeds: Vec<&[u8]> = vec![&pubkey_seed, &slot_seed, &violation_seed];
-    let (pda, bump) = Pubkey::find_program_address(&seeds, &id());
-    let bump_seed = [bump];
-    seeds.push(&bump_seed);
+    let report_address = ViolationReportAddress::new(&report);
+    let report_key = report_address.key();
+    let seeds = report_address.seeds();
+    let cpi_accounts = [
+        accounts.violation_pda_account.clone(),
+        accounts.system_program_account.clone(),
+    ];
 
-    if pda != *accounts.violation_account() {
+    if *report_key != *accounts.violation_account() {
         return Err(ProgramError::from(
             SlashingError::InvalidViolationReportAcccount,
         ));
@@ -242,7 +244,7 @@ where
         msg!(
             "{} violation verified in slot {} however the violation has already been reported",
             T::PROOF_TYPE.violation_str(),
-            u64::from(slot),
+            u64::from(report.slot),
         );
         return Err(ProgramError::from(SlashingError::DuplicateReport));
     }
@@ -255,15 +257,8 @@ where
     }
 
     // Assign the slashing program as the owner
-    let assign_instruction = system_instruction::assign(&pda, &id());
-    invoke_signed(
-        &assign_instruction,
-        &[
-            accounts.violation_pda_account.clone(),
-            accounts.system_program_account.clone(),
-        ],
-        &[&seeds],
-    )?;
+    let assign_instruction = system_instruction::assign(report_key, &id());
+    invoke_signed(&assign_instruction, &cpi_accounts, &[&seeds])?;
 
     // Allocate enough space for the report
     accounts.violation_pda_account.realloc(data_len, false)?;
@@ -280,6 +275,61 @@ where
 
     // Write the report
     accounts.write_violation_report(report, proof_data)
+}
+
+pub(crate) fn close_violation_report<'a, 'b>(
+    report_account: &'a AccountInfo<'b>,
+    destination_account: &'a AccountInfo<'b>,
+    system_program_account: &'a AccountInfo<'b>,
+) -> Result<(), ProgramError> {
+    let report_data = report_account.try_borrow_data()?;
+    let report: &ViolationReport =
+        pod_from_bytes(&report_data[0..std::mem::size_of::<ViolationReport>()])?;
+    let report_address = ViolationReportAddress::new(report);
+    let report_key = *report_address.key();
+    let destination = report.destination;
+
+    debug_assert_eq!(*report_account.key, report_key);
+
+    if Epoch::from(report.epoch).saturating_add(3) > sysvar::clock::Clock::get()?.epoch {
+        return Err(ProgramError::from(
+            SlashingError::CloseViolationReportTooSoon,
+        ));
+    }
+
+    if destination != *destination_account.key {
+        return Err(ProgramError::from(SlashingError::InvalidDestinationAccount));
+    }
+
+    // Copy seeds and drop as we will modify the report account
+    let seeds = report_address.seeds_owned();
+    let seeds: Vec<&[u8]> = seeds.iter().map(|seed| &seed[..]).collect();
+    drop(report_data);
+
+    // Reallocate the account to 0 bytes
+    report_account.realloc(0, false)?;
+
+    // Assign the system program as the owner
+    report_account.assign(&system_program::id());
+
+    // Transfer the lamports to the destination address
+    let lamports = report_account.lamports();
+    let transfer_instruction = system_instruction::transfer(&report_key, &destination, lamports);
+    invoke_signed(
+        &transfer_instruction,
+        &[
+            report_account.clone(),
+            destination_account.clone(),
+            system_program_account.clone(),
+        ],
+        &[&seeds],
+    )?;
+
+    msg!(
+        "Closed violation report and credited {} lamports to the destination address",
+        lamports
+    );
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
After a violation report has been written and at least 3 epochs have passed, anyone can close the report account and credit the lamports to the `destination` account specified on the report.

Requires write access to the report account, and the destination account and then:
* Check that we own the report account and it is not empty
* Check that `current epoch >= report epoch + 3`
* Check that the destination account matches the destination specified on the report
* Realloc the report account to 0 bytes and assign the system program as the owner
* Transfer all the lamports from report account to the destination account

