### PR TITLE
report: remove proof account field

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -91,7 +91,6 @@ pub fn process_instruction(
                 pubkey: data.node_pubkey,
                 slot: data.slot,
                 violation_type: u8::from(ProofType::DuplicateBlockProof),
-                proof_account: *accounts.proof_account(),
             };
             verify_proof_data::<DuplicateBlockProofData>(
                 violation_report,
@@ -274,7 +273,6 @@ mod tests {
             pubkey: leader.pubkey(),
             slot: PodU64::from(SLOT),
             violation_type: u8::from(ProofType::DuplicateBlockProof),
-            proof_account: Pubkey::new_unique(),
         };
 
         verify_proof_data::<DuplicateBlockProofData>(

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -135,10 +135,6 @@ impl<'a, 'b> SlashingAccounts<'a, 'b> {
         Ok(res)
     }
 
-    pub(crate) fn proof_account(&self) -> &Pubkey {
-        self.proof_account.key
-    }
-
     fn violation_account(&self) -> &Pubkey {
         self.violation_pda_account.key
     }
@@ -167,7 +163,7 @@ impl<'a, 'b> SlashingAccounts<'a, 'b> {
 }
 
 /// On chain proof report of a slashable violation
-/// The report account will contain this optionally followed by the
+/// The report account will contain this followed by the
 /// serialized proof
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable, PartialEq)]
@@ -186,8 +182,6 @@ pub struct ViolationReport {
     pub slot: PodSlot,
     /// Discriminant of `ProofType` representing the violation type
     pub violation_type: u8,
-    /// Account where the proof is stored
-    pub proof_account: Pubkey,
 }
 
 impl ViolationReport {

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -357,7 +357,6 @@ async fn valid_proof_data() {
         pubkey: leader.pubkey(),
         slot: PodU64::from(slot),
         violation_type: ProofType::DuplicateBlockProof.into(),
-        proof_account: account.pubkey(),
     };
     assert_eq!(*violation_report, expected_violation_report);
 
@@ -456,7 +455,6 @@ async fn valid_proof_coding() {
         pubkey: leader.pubkey(),
         slot: PodU64::from(slot),
         violation_type: ProofType::DuplicateBlockProof.into(),
-        proof_account: account.pubkey(),
     };
     assert_eq!(*violation_report, expected_violation_report);
 
@@ -856,7 +854,6 @@ async fn double_report() {
         pubkey: leader.pubkey(),
         slot: PodU64::from(slot),
         violation_type: ProofType::DuplicateBlockProof.into(),
-        proof_account: account.pubkey(),
     };
     assert_eq!(*violation_report, expected_violation_report);
 
@@ -1043,7 +1040,6 @@ async fn close_report_destination_and_early() {
         pubkey: leader.pubkey(),
         slot: PodU64::from(slot),
         violation_type: ProofType::DuplicateBlockProof.into(),
-        proof_account: account.pubkey(),
     };
     assert_eq!(*violation_report, expected_violation_report);
 


### PR DESCRIPTION
After further consideration of future slashing cases I believe this field is unnecessary and if needed can be added back.
We currently serialize the proof in the report account, and I believe we can continue doing so for future cases.

It creates an burden for the client to manage these proof accounts and also ensure that they are closed. 