### PR TITLE
instruction: allow separate keypair for prefunding pda

### DIFF
--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -198,6 +198,7 @@ fn slashing_instructions(
     duplicate_block_proof_with_sigverify_and_prefund(
         proof_account,
         &instruction_data,
+        None,
         &Rent::default(),
     )
 }

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -53,5 +53,4 @@ merkle
 retransmitter/SM
 FEC
 sigverify
-prefunded
-prefunding
+prefund/GD


### PR DESCRIPTION
Users might use a separate keypair as their fee payer, we should allow them to prefund the pda with their fee payer of choice. 