### PR TITLE
cli: add slashing client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7806,7 +7806,6 @@ dependencies = [
  "spl-pod",
  "spl-record",
  "spl-token",
- "spl-token-client",
  "tempfile",
  "test-case",
  "tokio",
@@ -9083,37 +9082,6 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-token-client"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bf4fb4f625f07c07d28ec885c848c2a08900c1e0ad937516b8e55c8ed49434"
-dependencies = [
- "async-trait",
- "bincode",
- "bytemuck",
- "futures 0.3.31",
- "futures-util",
- "solana-banks-interface",
- "solana-cli-output",
- "solana-program-test",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-sdk",
- "spl-associated-token-account-client",
- "spl-elgamal-registry",
- "spl-memo",
- "spl-record",
- "spl-token",
- "spl-token-2022 7.0.0",
- "spl-token-confidential-transfer-proof-extraction",
- "spl-token-confidential-transfer-proof-generation 0.3.0",
- "spl-token-group-interface",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7776,6 +7776,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-slashing-cli"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "clap 3.2.25",
+ "console",
+ "futures 0.3.31",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "serial_test",
+ "solana-account-decoder",
+ "solana-clap-v3-utils",
+ "solana-cli-config",
+ "solana-cli-output",
+ "solana-client",
+ "solana-ledger",
+ "solana-logger",
+ "solana-remote-wallet",
+ "solana-sdk",
+ "solana-slashing-program",
+ "solana-system-interface",
+ "solana-test-validator",
+ "solana-transaction-status",
+ "spl-pod",
+ "spl-record",
+ "spl-token",
+ "spl-token-client",
+ "tempfile",
+ "test-case",
+ "tokio",
+]
+
+[[package]]
+name = "solana-slashing-program"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "bitflags 2.9.0",
+ "bytemuck",
+ "lazy_static",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "rand 0.9.0",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_with",
+ "solana-client",
+ "solana-entry",
+ "solana-ledger",
+ "solana-program",
+ "solana-program-test",
+ "solana-sdk",
+ "solana-signature",
+ "solana-system-program",
+ "spl-pod",
+ "spl-record",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "solana-slot-hashes"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8925,72 +8991,6 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spl-slashing"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "bitflags 2.9.0",
- "bytemuck",
- "lazy_static",
- "num-derive",
- "num-traits",
- "num_enum",
- "rand 0.9.0",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_with",
- "solana-client",
- "solana-entry",
- "solana-ledger",
- "solana-program",
- "solana-program-test",
- "solana-sdk",
- "solana-signature",
- "solana-system-program",
- "spl-pod",
- "spl-record",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "spl-slashing-cli"
-version = "0.1.0"
-dependencies = [
- "bincode",
- "bytemuck",
- "clap 3.2.25",
- "console",
- "futures 0.3.31",
- "lazy_static",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "serial_test",
- "solana-account-decoder",
- "solana-clap-v3-utils",
- "solana-cli-config",
- "solana-cli-output",
- "solana-client",
- "solana-ledger",
- "solana-logger",
- "solana-remote-wallet",
- "solana-sdk",
- "solana-system-interface",
- "solana-test-validator",
- "solana-transaction-status",
- "spl-pod",
- "spl-record",
- "spl-slashing",
- "spl-token",
- "spl-token-client",
- "tempfile",
- "test-case",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
 ]
@@ -61,6 +61,61 @@ dependencies = [
  "polyval",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "affinity"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763e484feceb7dd021b21c5c6f81aee06b1594a743455ec7efbf72e6355e447b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "errno",
+ "libc",
+ "num_cpus",
+]
+
+[[package]]
+name = "agave-banking-stage-ingress-types"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1fb85c09da8aebdb52e9ecb6e66d359a02efacd4b40c6cd79f50039327bf4e"
+dependencies = [
+ "crossbeam-channel",
+ "solana-perf",
+]
+
+[[package]]
+name = "agave-geyser-plugin-interface"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df63ffb691b27f0253e893d083126cbe98a6b1ace29108992310f323f1ac50b0"
+dependencies = [
+ "log",
+ "solana-clock",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-status",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "agave-thread-manager"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc27cbfbda0a3c19799936ad20b802db086c20105323d1d8885da4e7d5bf4ec"
+dependencies = [
+ "affinity",
+ "anyhow",
+ "cfg-if 1.0.0",
+ "log",
+ "num_cpus",
+ "rayon",
+ "serde",
+ "solana-metrics",
+ "thread-priority",
+ "tokio",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -96,7 +151,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
@@ -146,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -431,7 +495,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -467,7 +531,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -515,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -624,7 +688,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "constant_time_eq",
  "digest 0.10.7",
 ]
@@ -746,6 +810,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +925,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -914,7 +994,61 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.6",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width 0.1.14",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.16.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -958,7 +1092,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -968,7 +1102,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -989,6 +1123,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1154,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a03115cc34fb0d7c321dd154a3914b3ca082ccc5c11d91bf7117dbbe7171f"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "num_cpus",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,7 +1180,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1111,7 +1272,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -1154,7 +1315,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.99",
 ]
 
@@ -1175,7 +1336,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1210,6 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1227,6 +1389,64 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+ "unicode-xid",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -1265,6 +1485,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,7 +1525,7 @@ dependencies = [
  "dlopen2_derive",
  "libc",
  "once_cell",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1303,6 +1544,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "eager"
@@ -1375,7 +1622,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1441,6 +1688,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b0ea5ef6dc2388a4b1669fa32097249bc03a15417b97cb75e38afb309e4a89"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,7 +1763,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "libredox",
  "windows-sys 0.59.0",
@@ -1579,7 +1842,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -1593,6 +1856,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -1634,6 +1903,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1677,6 +1947,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1706,7 +1977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1715,7 +1986,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
@@ -1728,7 +1999,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -1741,7 +2012,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "windows-targets 0.52.6",
@@ -1760,13 +2031,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "goauth"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8af59a261bcf42f45d1b261232847b9b850ba0a1419d6100698246fb66e9240"
 dependencies = [
  "arc-swap",
- "futures",
+ "futures 0.3.31",
  "log",
  "reqwest",
  "serde",
@@ -1784,9 +2068,9 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dashmap",
- "futures",
+ "futures 0.3.31",
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
@@ -1907,6 +2191,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hidapi"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b876ecf37e86b359573c16c8366bc3eba52b689884a0fc42ba3f67203d2a8b"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,7 +2325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
  "bytes",
- "futures",
+ "futures 0.3.31",
  "headers",
  "http",
  "hyper",
@@ -2221,6 +2524,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -2295,6 +2609,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2305,6 +2620,8 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -2316,7 +2633,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
 ]
 
@@ -2335,7 +2652,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2408,12 +2725,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "jsonrpc-client-transports"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
+dependencies = [
+ "derive_more 0.99.19",
+ "futures 0.3.31",
+ "jsonrpc-core",
+ "jsonrpc-pubsub",
+ "log",
+ "serde",
+ "serde_json",
+ "url 1.7.2",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures",
+ "futures 0.3.31",
  "futures-executor",
  "futures-util",
  "log",
@@ -2423,12 +2767,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core-client"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
+dependencies = [
+ "futures 0.3.31",
+ "jsonrpc-client-transports",
+]
+
+[[package]]
+name = "jsonrpc-derive"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
+dependencies = [
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "jsonrpc-http-server"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
+dependencies = [
+ "futures 0.3.31",
+ "hyper",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log",
+ "net2",
+ "parking_lot 0.11.2",
+ "unicase",
+]
+
+[[package]]
+name = "jsonrpc-pubsub"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
+dependencies = [
+ "futures 0.3.31",
+ "jsonrpc-core",
+ "lazy_static",
+ "log",
+ "parking_lot 0.11.2",
+ "rand 0.7.3",
+ "serde",
+]
+
+[[package]]
+name = "jsonrpc-server-utils"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
+dependencies = [
+ "bytes",
+ "futures 0.3.31",
+ "globset",
+ "jsonrpc-core",
+ "lazy_static",
+ "log",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "unicase",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -2460,11 +2885,21 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-targets 0.52.6",
 ]
 
@@ -2628,6 +3063,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +3127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "min-max-heap"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2687e6cf9c00f48e9284cf9fd15f2ef341d03cc7743abf9df4c5f07fdee50b18"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,7 +3164,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -2732,7 +3179,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2783,13 +3230,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cfg_aliases",
  "libc",
  "memoffset",
@@ -3000,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3060,11 +3518,17 @@ dependencies = [
  "futures-util",
  "js-sys",
  "lazy_static",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project",
  "rand 0.8.5",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking"
@@ -3099,12 +3563,12 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3113,7 +3577,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.5.10",
  "smallvec",
@@ -3125,6 +3589,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -3146,6 +3619,12 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
@@ -3157,6 +3636,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
 dependencies = [
  "num",
+]
+
+[[package]]
+name = "pest"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3213,7 +3737,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -3271,6 +3795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,12 +3811,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prio-graph"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f28921629370a46cf564f6ba1828bd8d1c97f7fad4ee9d1c6438f92feed6b8d"
+dependencies = [
+ "ahash 0.8.11",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3296,6 +3835,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -3417,7 +3980,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -3443,7 +4006,7 @@ dependencies = [
  "raw-cpuid",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3681,6 +4244,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "reed-solomon-erasure"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,7 +4323,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
@@ -3763,7 +4337,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util 0.7.13",
  "tower-service",
- "url",
+ "url 2.5.4",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3793,7 +4367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
  "untrusted",
@@ -3808,6 +4382,36 @@ checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rolling-file"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4007,6 +4611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4643,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "security-framework"
@@ -4121,6 +4740,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,9 +4766,16 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -4156,12 +4791,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.7.1",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures 0.3.31",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -4173,7 +4859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -4185,7 +4871,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -4208,6 +4894,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
@@ -4291,6 +4983,21 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures 0.3.31",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1",
 ]
 
 [[package]]
@@ -4486,7 +5193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420dc40674f4a4df1527277033554b1a1b84a47e780cdb7dad151426f5292e55"
 dependencies = [
  "borsh 1.5.5",
- "futures",
+ "futures 0.3.31",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
@@ -4516,7 +5223,7 @@ checksum = "8ea32797f631ff60b3eb3c793b0fddd104f5ffdf534bf6efcc59fbe30cd23b15"
 dependencies = [
  "bincode",
  "crossbeam-channel",
- "futures",
+ "futures 0.3.31",
  "solana-banks-interface",
  "solana-client",
  "solana-feature-set",
@@ -4562,6 +5269,22 @@ dependencies = [
  "solana-define-syscall",
  "solana-hash",
  "solana-sanitize",
+]
+
+[[package]]
+name = "solana-bloom"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf4babf9225c318efa34d7017eb3b881ed530732ad4dc59dfbde07f6144f27a"
+dependencies = [
+ "bv",
+ "fnv",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "solana-sanitize",
+ "solana-time-utils",
 ]
 
 [[package]]
@@ -4704,6 +5427,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-clap-utils"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9ef7be5c7a6fde4ae6864279a98d48a9454f70b0d3026bc37329e7f632fba6"
+dependencies = [
+ "chrono",
+ "clap 2.34.0",
+ "rpassword",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-commitment-config",
+ "solana-derivation-path",
+ "solana-hash",
+ "solana-keypair",
+ "solana-message",
+ "solana-native-token",
+ "solana-presigner",
+ "solana-pubkey",
+ "solana-remote-wallet",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.12",
+ "tiny-bip39",
+ "uriparse",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "solana-clap-v3-utils"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e0d663063c8949b0f71b96b5116acd46322072c8be5d1f0e385e72a3941fb"
+dependencies = [
+ "chrono",
+ "clap 3.2.25",
+ "rpassword",
+ "solana-clock",
+ "solana-cluster-type",
+ "solana-commitment-config",
+ "solana-derivation-path",
+ "solana-hash",
+ "solana-keypair",
+ "solana-message",
+ "solana-native-token",
+ "solana-presigner",
+ "solana-pubkey",
+ "solana-remote-wallet",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+ "solana-zk-token-sdk",
+ "thiserror 2.0.12",
+ "tiny-bip39",
+ "uriparse",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "solana-cli-config"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdfa01757b1e6016028ad3bb35eb8efd022aadab0155621aedd71f0c566f03a"
+dependencies = [
+ "dirs-next",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+ "solana-clap-utils",
+ "solana-commitment-config",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "solana-cli-output"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07214f677077717053580642e7c7f90d471d03a48874792e5fca876443dff830"
+dependencies = [
+ "Inflector",
+ "base64 0.22.1",
+ "chrono",
+ "clap 2.34.0",
+ "console",
+ "humantime",
+ "indicatif",
+ "pretty-hex",
+ "semver",
+ "serde",
+ "serde_json",
+ "solana-account",
+ "solana-account-decoder",
+ "solana-bincode",
+ "solana-clap-utils",
+ "solana-cli-config",
+ "solana-clock",
+ "solana-epoch-info",
+ "solana-hash",
+ "solana-message",
+ "solana-native-token",
+ "solana-packet",
+ "solana-program",
+ "solana-pubkey",
+ "solana-reserved-account-keys",
+ "solana-rpc-client-api",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-system-interface",
+ "solana-sysvar",
+ "solana-transaction",
+ "solana-transaction-error",
+ "solana-transaction-status",
+ "solana-vote-program",
+ "spl-memo",
+]
+
+[[package]]
 name = "solana-client"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,7 +5554,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
- "futures",
+ "futures 0.3.31",
  "futures-util",
  "indexmap 2.7.1",
  "indicatif",
@@ -4904,6 +5746,101 @@ dependencies = [
  "solana-transaction-error",
  "thiserror 2.0.12",
  "tokio",
+]
+
+[[package]]
+name = "solana-core"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6ddd0c2515aa9fcb6107796fe4af5af17b9d1e49eeb8756588a443b7a8ab20"
+dependencies = [
+ "agave-banking-stage-ingress-types",
+ "agave-thread-manager",
+ "agave-transaction-view",
+ "ahash 0.8.11",
+ "anyhow",
+ "arrayvec",
+ "assert_matches",
+ "base64 0.22.1",
+ "bincode",
+ "bs58",
+ "bytes",
+ "chrono",
+ "crossbeam-channel",
+ "dashmap",
+ "etcd-client",
+ "futures 0.3.31",
+ "histogram",
+ "itertools 0.12.1",
+ "lazy_static",
+ "log",
+ "lru",
+ "min-max-heap",
+ "num_enum",
+ "prio-graph",
+ "qualifier_attr",
+ "quinn",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "rolling-file",
+ "rustls 0.23.23",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "slab",
+ "solana-accounts-db",
+ "solana-bloom",
+ "solana-builtins-default-costs",
+ "solana-client",
+ "solana-compute-budget",
+ "solana-compute-budget-instruction",
+ "solana-connection-cache",
+ "solana-cost-model",
+ "solana-entry",
+ "solana-feature-set",
+ "solana-fee",
+ "solana-geyser-plugin-manager",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-perf",
+ "solana-poh",
+ "solana-pubkey",
+ "solana-quic-client",
+ "solana-rayon-threadlimit",
+ "solana-rpc",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-runtime-transaction",
+ "solana-sanitize",
+ "solana-sdk",
+ "solana-sdk-ids",
+ "solana-send-transaction-service",
+ "solana-short-vec",
+ "solana-streamer",
+ "solana-svm",
+ "solana-svm-transaction",
+ "solana-timings",
+ "solana-tls-utils",
+ "solana-tpu-client",
+ "solana-transaction-status",
+ "solana-turbine",
+ "solana-unified-scheduler-pool",
+ "solana-version",
+ "solana-vote",
+ "solana-vote-program",
+ "solana-wen-restart",
+ "strum",
+ "strum_macros",
+ "sys-info",
+ "sysctl",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tokio",
+ "trees",
 ]
 
 [[package]]
@@ -5101,6 +6038,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-faucet"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8bd25a809e1763794de4c28d699d859d77947fd7c6b11883c781d2cdfb3cf2"
+dependencies = [
+ "bincode",
+ "clap 2.34.0",
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "solana-clap-utils",
+ "solana-cli-config",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-logger",
+ "solana-message",
+ "solana-metrics",
+ "solana-native-token",
+ "solana-packet",
+ "solana-pubkey",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-system-transaction",
+ "solana-transaction",
+ "solana-version",
+ "spl-memo",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "solana-feature-gate-interface"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,6 +6166,91 @@ dependencies = [
  "solana-shred-version",
  "solana-signer",
  "solana-time-utils",
+]
+
+[[package]]
+name = "solana-geyser-plugin-manager"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8287469a6f059411a3940bbc1b0a428b27104827ae1a80e465a1139f8b0773"
+dependencies = [
+ "agave-geyser-plugin-interface",
+ "bs58",
+ "crossbeam-channel",
+ "json5",
+ "jsonrpc-core",
+ "libloading 0.7.4",
+ "log",
+ "serde_json",
+ "solana-account",
+ "solana-accounts-db",
+ "solana-clock",
+ "solana-entry",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubkey",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-status",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
+name = "solana-gossip"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "587f7e73d3ee7173f1f66392f1aeb4e582c055ad30f4e40f3a4b2cf9bce434fe"
+dependencies = [
+ "assert_matches",
+ "bincode",
+ "bv",
+ "clap 2.34.0",
+ "crossbeam-channel",
+ "flate2",
+ "indexmap 2.7.1",
+ "itertools 0.12.1",
+ "log",
+ "lru",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "serde_derive",
+ "siphasher",
+ "solana-bloom",
+ "solana-clap-utils",
+ "solana-client",
+ "solana-connection-cache",
+ "solana-entry",
+ "solana-feature-set",
+ "solana-ledger",
+ "solana-logger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-perf",
+ "solana-pubkey",
+ "solana-rayon-threadlimit",
+ "solana-rpc-client",
+ "solana-runtime",
+ "solana-sanitize",
+ "solana-sdk",
+ "solana-serde-varint",
+ "solana-short-vec",
+ "solana-streamer",
+ "solana-tpu-client",
+ "solana-version",
+ "solana-vote",
+ "solana-vote-program",
+ "static_assertions",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5353,7 +6408,7 @@ dependencies = [
  "dashmap",
  "eager",
  "fs_extra",
- "futures",
+ "futures 0.3.31",
  "itertools 0.12.1",
  "lazy-lru",
  "lazy_static",
@@ -5594,7 +6649,7 @@ dependencies = [
  "socket2",
  "solana-serde",
  "tokio",
- "url",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -5689,6 +6744,29 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-time-utils",
+]
+
+[[package]]
+name = "solana-poh"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3abf53e6af2bc7f3ebd455112a0eb960378882d780e85b62ff3a70b69e02e6"
+dependencies = [
+ "core_affinity",
+ "crossbeam-channel",
+ "log",
+ "solana-clock",
+ "solana-entry",
+ "solana-hash",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-poh-config",
+ "solana-pubkey",
+ "solana-runtime",
+ "solana-time-utils",
+ "solana-transaction",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6013,7 +7091,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tungstenite",
- "url",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -6024,7 +7102,7 @@ checksum = "0d072e6787b6fa9da86591bcf870823b0d6f87670df3c92628505db7a9131e44"
 dependencies = [
  "async-lock",
  "async-trait",
- "futures",
+ "futures 0.3.31",
  "itertools 0.12.1",
  "lazy_static",
  "log",
@@ -6064,6 +7142,30 @@ checksum = "17f7b65ddd8ac75efcc31b627d4f161046312994313a4520b65a8b14202ab5d6"
 dependencies = [
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "solana-remote-wallet"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa3c1e6ec719021564b034c550f808778507db54b6a5de99f00799d9ec86168d"
+dependencies = [
+ "console",
+ "dialoguer",
+ "hidapi",
+ "log",
+ "num-derive",
+ "num-traits",
+ "parking_lot 0.12.3",
+ "qstring",
+ "semver",
+ "solana-derivation-path",
+ "solana-offchain-message",
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+ "thiserror 2.0.12",
+ "uriparse",
 ]
 
 [[package]]
@@ -6126,6 +7228,68 @@ checksum = "18205b69139b1ae0ab8f6e11cdcb627328c0814422ad2482000fa2ca54ae4a2f"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "solana-rpc"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b978303a9d6f3270ab83fa28ad07a2f4f3181a65ce332b4b5f5d06de5f2a46c5"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bs58",
+ "crossbeam-channel",
+ "dashmap",
+ "itertools 0.12.1",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "jsonrpc-http-server",
+ "jsonrpc-pubsub",
+ "libc",
+ "log",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "soketto",
+ "solana-account-decoder",
+ "solana-accounts-db",
+ "solana-client",
+ "solana-entry",
+ "solana-faucet",
+ "solana-feature-set",
+ "solana-gossip",
+ "solana-inline-spl",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-perf",
+ "solana-poh",
+ "solana-pubkey",
+ "solana-rayon-threadlimit",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-runtime-transaction",
+ "solana-sdk",
+ "solana-send-transaction-service",
+ "solana-stake-program",
+ "solana-storage-bigtable",
+ "solana-streamer",
+ "solana-svm",
+ "solana-tpu-client",
+ "solana-transaction-status",
+ "solana-version",
+ "solana-vote",
+ "solana-vote-program",
+ "spl-token",
+ "spl-token-2022 7.0.0",
+ "stream-cancel",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -6341,7 +7505,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-demangle",
  "thiserror 1.0.69",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6502,7 +7666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
 dependencies = [
  "hmac 0.12.1",
- "pbkdf2",
+ "pbkdf2 0.11.0",
  "sha2 0.10.8",
 ]
 
@@ -6709,7 +7873,7 @@ dependencies = [
  "bzip2",
  "enum-iterator",
  "flate2",
- "futures",
+ "futures 0.3.31",
  "goauth",
  "http",
  "hyper",
@@ -6774,7 +7938,7 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "dashmap",
- "futures",
+ "futures 0.3.31",
  "futures-util",
  "governor",
  "histogram",
@@ -6981,6 +8145,39 @@ checksum = "5762b273d3325b047cfda250787f8d796d781746860d5d0a746ee29f3e8812c1"
 dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-test-validator"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723ed26f24b185c36d476b8cd69c1b727ce2074d7342099aa56fce20bec19280"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "crossbeam-channel",
+ "log",
+ "serde_derive",
+ "serde_json",
+ "solana-accounts-db",
+ "solana-cli-output",
+ "solana-compute-budget",
+ "solana-core",
+ "solana-feature-set",
+ "solana-geyser-plugin-manager",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-logger",
+ "solana-net-utils",
+ "solana-program-test",
+ "solana-rpc",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-streamer",
+ "solana-tpu-client",
+ "tokio",
 ]
 
 [[package]]
@@ -7214,6 +8411,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-turbine"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a646980cf7729a5f9b01e90a8707eb4b045525c894b538ddf91bd43d216a187"
+dependencies = [
+ "bincode",
+ "bytes",
+ "crossbeam-channel",
+ "futures 0.3.31",
+ "itertools 0.12.1",
+ "lazy-lru",
+ "log",
+ "lru",
+ "quinn",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "rustls 0.23.23",
+ "solana-entry",
+ "solana-feature-set",
+ "solana-geyser-plugin-manager",
+ "solana-gossip",
+ "solana-ledger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-perf",
+ "solana-poh",
+ "solana-quic-client",
+ "solana-rayon-threadlimit",
+ "solana-rpc",
+ "solana-rpc-client-api",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-streamer",
+ "solana-tls-utils",
+ "static_assertions",
+ "thiserror 2.0.12",
+ "tokio",
+]
+
+[[package]]
 name = "solana-type-overrides"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7250,6 +8489,37 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-transaction",
  "static_assertions",
+]
+
+[[package]]
+name = "solana-unified-scheduler-pool"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9854eb81245123b84af5807731a43aa794961990feaf5a8526127c5898e097"
+dependencies = [
+ "agave-banking-stage-ingress-types",
+ "aquamarine",
+ "assert_matches",
+ "crossbeam-channel",
+ "dashmap",
+ "derive-where",
+ "derive_more 1.0.0",
+ "dyn-clone",
+ "log",
+ "qualifier_attr",
+ "scopeguard",
+ "solana-ledger",
+ "solana-poh",
+ "solana-pubkey",
+ "solana-runtime",
+ "solana-runtime-transaction",
+ "solana-timings",
+ "solana-transaction",
+ "solana-transaction-error",
+ "solana-unified-scheduler-logic",
+ "static_assertions",
+ "trait-set",
+ "vec_extract_if_polyfill",
 ]
 
 [[package]]
@@ -7352,6 +8622,33 @@ dependencies = [
  "solana-transaction-context",
  "solana-vote-interface",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "solana-wen-restart"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23183976f151b510f8ed2f2088c7c47324f2e50a2cca3370faefc2683d0e45d"
+dependencies = [
+ "anyhow",
+ "log",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "protobuf-src",
+ "rayon",
+ "solana-clock",
+ "solana-entry",
+ "solana-gossip",
+ "solana-hash",
+ "solana-ledger",
+ "solana-program",
+ "solana-pubkey",
+ "solana-runtime",
+ "solana-shred-version",
+ "solana-time-utils",
+ "solana-timings",
+ "solana-vote-program",
 ]
 
 [[package]]
@@ -7660,6 +8957,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-slashing-cli"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "clap 3.2.25",
+ "console",
+ "futures 0.3.31",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "serial_test",
+ "solana-account-decoder",
+ "solana-clap-v3-utils",
+ "solana-cli-config",
+ "solana-cli-output",
+ "solana-client",
+ "solana-ledger",
+ "solana-logger",
+ "solana-remote-wallet",
+ "solana-sdk",
+ "solana-system-interface",
+ "solana-test-validator",
+ "solana-transaction-status",
+ "spl-pod",
+ "spl-record",
+ "spl-slashing",
+ "spl-token",
+ "spl-token-client",
+ "tempfile",
+ "test-case",
+ "tokio",
+]
+
+[[package]]
 name = "spl-tlv-account-resolution"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7749,6 +9083,37 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "spl-token-client"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bf4fb4f625f07c07d28ec885c848c2a08900c1e0ad937516b8e55c8ed49434"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "bytemuck",
+ "futures 0.3.31",
+ "futures-util",
+ "solana-banks-interface",
+ "solana-cli-output",
+ "solana-program-test",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
+ "spl-associated-token-account-client",
+ "spl-elgamal-registry",
+ "spl-memo",
+ "spl-record",
+ "spl-token",
+ "spl-token-2022 7.0.0",
+ "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-generation 0.3.0",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface",
+ "spl-transfer-hook-interface",
  "thiserror 2.0.12",
 ]
 
@@ -7896,6 +9261,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stream-cancel"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7987,6 +9375,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e483f02d0ad107168dc57381a8a40c3aeea6abe47f37506931f861643cfa8"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8026,7 +9437,7 @@ checksum = "1c38a012bed6fb9681d3bf71ffaa4f88f3b4b9ed3198cda6e4c8462d24d4bb80"
 dependencies = [
  "anyhow",
  "fnv",
- "futures",
+ "futures 0.3.31",
  "humantime",
  "opentelemetry",
  "pin-project",
@@ -8068,7 +9479,7 @@ version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
@@ -8090,6 +9501,54 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+ "test-case-core",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -8132,12 +9591,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-priority"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -8170,6 +9643,25 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-bip39"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
+ "rustc-hash 1.1.0",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]
@@ -8321,6 +9813,7 @@ checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -8336,10 +9829,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -8348,6 +9856,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.1",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -8370,7 +9880,7 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-timeout",
- "percent-encoding",
+ "percent-encoding 2.3.1",
  "pin-project",
  "prost",
  "rustls-pemfile 1.0.4",
@@ -8486,6 +9996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-set"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79e2e9c9ab44c6d7c20d5976961b47e8f49ac199154daa514b77cd1ab536625"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "trees"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8513,7 +10034,7 @@ dependencies = [
  "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.69",
- "url",
+ "url 2.5.4",
  "utf-8",
  "webpki-roots 0.24.0",
 ]
@@ -8523,6 +10044,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"
@@ -8537,10 +10064,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -8574,6 +10128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8591,13 +10151,24 @@ dependencies = [
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna",
- "percent-encoding",
+ "idna 1.0.3",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -8629,6 +10200,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_extract_if_polyfill"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c9cb5fb67c2692310b6eb3fce7dd4b6e4c9a75be4f2f46b27f0b2b7799759c"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -8697,7 +10280,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -8723,7 +10306,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -8820,6 +10403,12 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -8827,6 +10416,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -9027,7 +10622,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["program"]
+members = ["program", "clients/cli"]
 
 [workspace.metadata.cli]
 solana = "2.2.0"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "spl-slashing-cli"
+version = "0.1.0"
+description = "Solana Program Library Slashing Command-line Utility"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+repository = "https://github.com/solana-program/single-pool"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+tokio = "1.43"
+clap = { version = "3.2.23", features = ["derive"] }
+console = "0.15.10"
+bincode = "1.3.1"
+bytemuck = "1.21.0"
+serde = "1.0.217"
+serde_derive = "1.0.103"
+serde_json = "1.0.138"
+serde_with = "3.12.0"
+solana-account-decoder = "2.2.0"
+solana-clap-v3-utils = "2.2.0"
+solana-cli-config = "2.2.0"
+solana-cli-output = "2.2.0"
+solana-client = "2.2.0"
+futures = "0.3.3"
+solana-logger = "2.2.0"
+solana-ledger = "2.2.0"
+solana-system-interface = "1.0.0"
+spl-pod = "0.5.0"
+solana-remote-wallet = "2.2.0"
+solana-sdk = "2.2.1"
+solana-transaction-status = "2.2.0"
+spl-token = { version = "7.0", features = ["no-entrypoint"] }
+lazy_static = "1.4.0"
+spl-token-client = { version = "0.14.0" }
+spl-slashing = { version = "0.1.0", path = "../../program", features = [
+  "no-entrypoint",
+] }
+spl-record = "0.3.0"
+
+[dev-dependencies]
+solana-test-validator = "2.2.0"
+serial_test = "3.2.0"
+test-case = "3.3"
+tempfile = "3.16.0"
+
+[[bin]]
+name = "spl-slashing"
+path = "src/main.rs"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -32,7 +32,6 @@ solana-sdk = "2.2.1"
 solana-transaction-status = "2.2.0"
 spl-token = { version = "7.0", features = ["no-entrypoint"] }
 lazy_static = "1.4.0"
-spl-token-client = { version = "0.14.0" }
 solana-slashing-program = { version = "0.1.0", path = "../../program", features = [
   "no-entrypoint",
 ] }

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spl-slashing-cli"
+name = "solana-slashing-cli"
 version = "0.1.0"
 description = "Solana Program Library Slashing Command-line Utility"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
@@ -33,7 +33,7 @@ solana-transaction-status = "2.2.0"
 spl-token = { version = "7.0", features = ["no-entrypoint"] }
 lazy_static = "1.4.0"
 spl-token-client = { version = "0.14.0" }
-spl-slashing = { version = "0.1.0", path = "../../program", features = [
+solana-slashing-program = { version = "0.1.0", path = "../../program", features = [
   "no-entrypoint",
 ] }
 spl-record = "0.3.0"

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -112,7 +112,7 @@ pub struct CloseCli {
     pub node_pubkey: Option<SignerSource>,
 
     /// The reporter whose reports to close
-    #[clap(long = "reporter", value_parser = PUBKEY_PARSER.clone())]
+    #[clap(long, value_parser = PUBKEY_PARSER.clone())]
     pub reporter: Option<SignerSource>,
 
     /// The destination address whose associated reports to close

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -97,7 +97,7 @@ pub struct DisplayCli {
     pub node_pubkey: Option<SignerSource>,
 
     /// The reporter whose reports to display
-    #[clap(long = "reporter", value_parser = PUBKEY_PARSER.clone())]
+    #[clap(long, value_parser = PUBKEY_PARSER.clone())]
     pub reporter: Option<SignerSource>,
 }
 
@@ -108,7 +108,7 @@ pub struct CloseCli {
     pub report_account: Option<SignerSource>,
 
     /// The validator whose violation reports to close
-    #[clap(long = "node_pubkey", value_parser = PUBKEY_PARSER.clone())]
+    #[clap(long, value_parser = PUBKEY_PARSER.clone())]
     pub node_pubkey: Option<SignerSource>,
 
     /// The reporter whose reports to close
@@ -116,32 +116,32 @@ pub struct CloseCli {
     pub reporter: Option<SignerSource>,
 
     /// The destination address whose associated reports to close
-    #[clap(long = "destination", value_parser = PUBKEY_PARSER.clone())]
+    #[clap(long, value_parser = PUBKEY_PARSER.clone())]
     pub destination: Option<SignerSource>,
 }
 
 #[derive(Clone, Debug, Args)]
 pub struct AttachCli {
-    /// The ledger to attach to
-    #[clap(short = 'l', long = "ledger")]
+    /// The path to the validator ledger directory to attach to
+    #[clap(short, long)]
     pub ledger: String,
 
     /// The reporting pubkey to publish on a successful report. Defaults to
     /// the default signer
-    #[clap(long = "reporter", value_parser = PUBKEY_PARSER.clone())]
+    #[clap(long, value_parser = PUBKEY_PARSER.clone())]
     pub reporter: Option<SignerSource>,
 
     /// The destination pubkey to credit upon closing a successful report.
     /// Defaults to the default signer
-    #[clap(long = "destination", value_parser = PUBKEY_PARSER.clone())]
+    #[clap(long, value_parser = PUBKEY_PARSER.clone())]
     pub destination: Option<SignerSource>,
 
     /// The start of the slot range to report violations for
-    #[clap(long = "start-slot")]
+    #[clap(long)]
     pub start_slot: Option<Slot>,
 
     /// The end of the slot range to report violations for
-    #[clap(long = "end-slot", conflicts_with = "continuous")]
+    #[clap(long, conflicts_with = "continuous")]
     pub end_slot: Option<Slot>,
 
     /// Specify to continuously check the ledger for new violations.
@@ -151,7 +151,7 @@ pub struct AttachCli {
     #[clap(long)]
     pub continuous: bool,
 
-    #[clap(long = "scan-interval", requires = "continuous")]
+    #[clap(long, requires = "continuous")]
     pub scan_interval: Option<u64>,
 }
 

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -146,7 +146,9 @@ pub struct AttachCli {
 
     /// Specify to continuously check the ledger for new violations.
     /// If specified without `scan_interval`, this will perform a scan once
-    /// a day (roughly 1/2 an epoch).
+    /// every 4 hours, this is chosen based on the default shred storage in
+    /// blockstore (`200M` shreds). Assuming `50k` TPS, ledger can hold 4.5
+    /// hours of shreds.
     /// Cannot be specified with the end slot argument
     #[clap(long)]
     pub continuous: bool,

--- a/clients/cli/src/cli.rs
+++ b/clients/cli/src/cli.rs
@@ -1,0 +1,164 @@
+use {
+    clap::{
+        builder::{PossibleValuesParser, TypedValueParser, ValueParser},
+        Args, Parser, Subcommand,
+    },
+    lazy_static::lazy_static,
+    solana_clap_v3_utils::input_parsers::{
+        parse_url_or_moniker,
+        signer::{SignerSource, SignerSourceParserBuilder},
+    },
+    solana_cli_output::OutputFormat,
+    solana_sdk::clock::{Epoch, Slot},
+};
+
+lazy_static! {
+    static ref SIGNER_PARSER: ValueParser =
+        SignerSourceParserBuilder::default().allow_all().build();
+    static ref PUBKEY_PARSER: ValueParser =
+        SignerSourceParserBuilder::default().allow_pubkey().build();
+}
+
+#[derive(Clone, Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Configuration file to use
+    #[clap(global(true), short = 'C', long = "config", id = "PATH")]
+    pub config_file: Option<String>,
+
+    /// Show additional information
+    #[clap(global(true), short, long)]
+    pub verbose: bool,
+
+    /// Simulate transaction instead of executing
+    #[clap(global(true), long, alias = "dryrun")]
+    pub dry_run: bool,
+
+    /// URL for Solana JSON RPC or moniker (or their first letter):
+    /// [mainnet-beta, testnet, devnet, localhost].
+    /// Default from the configuration file.
+    #[clap(
+        global(true),
+        short = 'u',
+        long = "url",
+        id = "URL_OR_MONIKER",
+        value_parser = parse_url_or_moniker,
+    )]
+    pub json_rpc_url: Option<String>,
+
+    /// Specify the fee-payer account. This may be a keypair file, the ASK
+    /// keyword or the pubkey of an offline signer, provided an appropriate
+    /// --signer argument is also passed. Defaults to the client keypair.
+    #[clap(
+        global(true),
+        long,
+        id = "PAYER_KEYPAIR",
+        value_parser = SIGNER_PARSER.clone(),
+    )]
+    pub fee_payer: Option<SignerSource>,
+
+    /// Return information in specified output format
+    #[clap(
+        global(true),
+        long = "output",
+        id = "FORMAT",
+        conflicts_with = "verbose",
+        value_parser = PossibleValuesParser::new(["json", "json-compact"]).map(|o| parse_output_format(&o)),
+    )]
+    pub output_format: Option<OutputFormat>,
+
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum Command {
+    /// Command to display existing reports filtered by criteria.
+    Display(DisplayCli),
+
+    /// Close any eligible reports that meet the epoch requirement.
+    /// Can filter by criteria
+    Close(CloseCli),
+
+    /// Attach to a validator's ledger directory and submit new violations.
+    /// Can filter to only submit on certain slots.
+    /// Can also be run in continuous mode to scan as the ledger is updated.
+    Attach(AttachCli),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct DisplayCli {
+    /// The epoch's reports to display
+    #[clap(long)]
+    pub epoch: Option<Epoch>,
+
+    /// The validator whose violation reports to display
+    #[clap(value_parser = PUBKEY_PARSER.clone())]
+    pub node_pubkey: Option<SignerSource>,
+
+    /// The reporter whose reports to display
+    #[clap(long = "reporter", value_parser = PUBKEY_PARSER.clone())]
+    pub reporter: Option<SignerSource>,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct CloseCli {
+    /// The report account to close
+    #[clap(value_parser = PUBKEY_PARSER.clone())]
+    pub report_account: Option<SignerSource>,
+
+    /// The validator whose violation reports to close
+    #[clap(long = "node_pubkey", value_parser = PUBKEY_PARSER.clone())]
+    pub node_pubkey: Option<SignerSource>,
+
+    /// The reporter whose reports to close
+    #[clap(long = "reporter", value_parser = PUBKEY_PARSER.clone())]
+    pub reporter: Option<SignerSource>,
+
+    /// The destination address whose associated reports to close
+    #[clap(long = "destination", value_parser = PUBKEY_PARSER.clone())]
+    pub destination: Option<SignerSource>,
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct AttachCli {
+    /// The ledger to attach to
+    #[clap(short = 'l', long = "ledger")]
+    pub ledger: String,
+
+    /// The reporting pubkey to publish on a successful report. Defaults to
+    /// the default signer
+    #[clap(long = "reporter", value_parser = PUBKEY_PARSER.clone())]
+    pub reporter: Option<SignerSource>,
+
+    /// The destination pubkey to credit upon closing a successful report.
+    /// Defaults to the default signer
+    #[clap(long = "destination", value_parser = PUBKEY_PARSER.clone())]
+    pub destination: Option<SignerSource>,
+
+    /// The start of the slot range to report violations for
+    #[clap(long = "start-slot")]
+    pub start_slot: Option<Slot>,
+
+    /// The end of the slot range to report violations for
+    #[clap(long = "end-slot", conflicts_with = "continuous")]
+    pub end_slot: Option<Slot>,
+
+    /// Specify to continuously check the ledger for new violations.
+    /// If specified without `scan_interval`, this will perform a scan once
+    /// a day (roughly 1/2 an epoch).
+    /// Cannot be specified with the end slot argument
+    #[clap(long)]
+    pub continuous: bool,
+
+    #[clap(long = "scan-interval", requires = "continuous")]
+    pub scan_interval: Option<u64>,
+}
+
+pub fn parse_output_format(output_format: &str) -> OutputFormat {
+    match output_format {
+        "json" => OutputFormat::Json,
+        "json-compact" => OutputFormat::JsonCompact,
+        _ => unreachable!(),
+    }
+}

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -5,9 +5,7 @@ use {
     solana_cli_output::OutputFormat,
     solana_client::nonblocking::rpc_client::RpcClient,
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
-    solana_sdk::{
-        commitment_config::CommitmentConfig, rent::Rent, signature::Signer, sysvar::SysvarId,
-    },
+    solana_sdk::{commitment_config::CommitmentConfig, signature::Signer},
     std::{process::exit, rc::Rc, sync::Arc},
 };
 
@@ -37,7 +35,6 @@ pub struct Config {
     pub fee_payer: Option<Arc<dyn Signer>>,
     pub output_format: OutputFormat,
     pub dry_run: bool,
-    pub rent: Rent,
 }
 impl Config {
     pub async fn new(
@@ -85,17 +82,12 @@ impl Config {
             (None, false) => OutputFormat::Display,
         };
 
-        // get rent
-        let rent =
-            bincode::deserialize(&rpc_client.get_account_data(&Rent::id()).await.unwrap()).unwrap();
-
         Self {
             rpc_client,
             default_signer,
             fee_payer,
             output_format,
             dry_run: cli.dry_run,
-            rent,
         }
     }
 

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -1,0 +1,138 @@
+use {
+    crate::cli::*,
+    clap::ArgMatches,
+    solana_clap_v3_utils::keypair::{signer_from_path, signer_from_source},
+    solana_cli_output::OutputFormat,
+    solana_client::nonblocking::rpc_client::RpcClient,
+    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_sdk::{
+        commitment_config::CommitmentConfig, rent::Rent, signature::Signer, sysvar::SysvarId,
+    },
+    spl_token_client::client::{ProgramClient, ProgramRpcClient, ProgramRpcClientSendTransaction},
+    std::{process::exit, rc::Rc, sync::Arc},
+};
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+
+pub fn println_display(config: &Config, message: String) {
+    match config.output_format {
+        OutputFormat::Display | OutputFormat::DisplayVerbose => {
+            println!("{}", message);
+        }
+        _ => {}
+    }
+}
+
+pub fn eprintln_display(config: &Config, message: String) {
+    match config.output_format {
+        OutputFormat::Display | OutputFormat::DisplayVerbose => {
+            eprintln!("{}", message);
+        }
+        _ => {}
+    }
+}
+
+pub struct Config {
+    pub rpc_client: Arc<RpcClient>,
+    pub program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>>,
+    pub default_signer: Option<Arc<dyn Signer>>,
+    pub fee_payer: Option<Arc<dyn Signer>>,
+    pub output_format: OutputFormat,
+    pub dry_run: bool,
+    pub rent: Rent,
+}
+impl Config {
+    pub async fn new(
+        cli: Cli,
+        matches: ArgMatches,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+    ) -> Self {
+        // get the generic cli config struct
+        let cli_config = if let Some(config_file) = &cli.config_file {
+            solana_cli_config::Config::load(config_file).unwrap_or_else(|_| {
+                eprintln!("error: Could not load config file `{}`", config_file);
+                exit(1);
+            })
+        } else if let Some(config_file) = &*solana_cli_config::CONFIG_FILE {
+            solana_cli_config::Config::load(config_file).unwrap_or_default()
+        } else {
+            solana_cli_config::Config::default()
+        };
+
+        // create rpc client
+        let rpc_client = Arc::new(RpcClient::new_with_commitment(
+            cli.json_rpc_url.unwrap_or(cli_config.json_rpc_url),
+            CommitmentConfig::confirmed(),
+        ));
+
+        // and program client
+        let program_client = Arc::new(ProgramRpcClient::new(
+            rpc_client.clone(),
+            ProgramRpcClientSendTransaction,
+        ));
+
+        // resolve default signer
+        let default_path = cli_config.keypair_path;
+        let default_signer = signer_from_path(&matches, &default_path, "default", wallet_manager)
+            .ok()
+            .map(Arc::from);
+
+        // resolve fee-payer
+        let fee_payer = cli
+            .fee_payer
+            .and_then(|source| {
+                signer_from_source(&matches, &source, "fee_payer", wallet_manager).ok()
+            })
+            .map(Arc::from)
+            .or(default_signer.clone());
+
+        // determine output format
+        let output_format = match (cli.output_format, cli.verbose) {
+            (Some(json_format), _) => json_format,
+            (None, true) => OutputFormat::DisplayVerbose,
+            (None, false) => OutputFormat::Display,
+        };
+
+        // get rent
+        let rent =
+            bincode::deserialize(&rpc_client.get_account_data(&Rent::id()).await.unwrap()).unwrap();
+
+        Self {
+            rpc_client,
+            program_client,
+            default_signer,
+            fee_payer,
+            output_format,
+            dry_run: cli.dry_run,
+            rent,
+        }
+    }
+
+    // Returns Ok(default signer), or Err if there is no default signer configured
+    pub fn default_signer(&self) -> Result<Arc<dyn Signer>, Error> {
+        if let Some(default_signer) = &self.default_signer {
+            Ok(default_signer.clone())
+        } else {
+            Err("default signer is required, please specify a valid default signer by identifying a \
+                 valid configuration file using the --config argument, or by creating a valid config \
+                 at the default location of ~/.config/solana/cli/config.yml using the solana config \
+                 command".to_string().into())
+        }
+    }
+
+    // Returns Ok(fee payer), or Err if there is no fee payer configured
+    pub fn fee_payer(&self) -> Result<Arc<dyn Signer>, Error> {
+        if let Some(fee_payer) = &self.fee_payer {
+            Ok(fee_payer.clone())
+        } else {
+            Err("fee payer is required, please specify a valid fee payer using the --payer argument, or \
+                 by identifying a valid configuration file using the --config argument, or by creating a \
+                 valid config at the default location of ~/.config/solana/cli/config.yml using the solana \
+                 config command".to_string().into())
+        }
+    }
+
+    pub fn verbose(&self) -> bool {
+        self.output_format == OutputFormat::DisplayVerbose
+    }
+}

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -8,7 +8,6 @@ use {
     solana_sdk::{
         commitment_config::CommitmentConfig, rent::Rent, signature::Signer, sysvar::SysvarId,
     },
-    spl_token_client::client::{ProgramClient, ProgramRpcClient, ProgramRpcClientSendTransaction},
     std::{process::exit, rc::Rc, sync::Arc},
 };
 
@@ -34,7 +33,6 @@ pub fn eprintln_display(config: &Config, message: String) {
 
 pub struct Config {
     pub rpc_client: Arc<RpcClient>,
-    pub program_client: Arc<dyn ProgramClient<ProgramRpcClientSendTransaction>>,
     pub default_signer: Option<Arc<dyn Signer>>,
     pub fee_payer: Option<Arc<dyn Signer>>,
     pub output_format: OutputFormat,
@@ -65,12 +63,6 @@ impl Config {
             CommitmentConfig::confirmed(),
         ));
 
-        // and program client
-        let program_client = Arc::new(ProgramRpcClient::new(
-            rpc_client.clone(),
-            ProgramRpcClientSendTransaction,
-        ));
-
         // resolve default signer
         let default_path = cli_config.keypair_path;
         let default_signer = signer_from_path(&matches, &default_path, "default", wallet_manager)
@@ -99,7 +91,6 @@ impl Config {
 
         Self {
             rpc_client,
-            program_client,
             default_signer,
             fee_payer,
             output_format,

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -47,8 +47,8 @@ use cli::*;
 mod output;
 use output::*;
 
-// Scan once a day
-const DEFAULT_SCAN_INTERVAL_S: u64 = 86400;
+// Scan once every 4 hours
+const DEFAULT_SCAN_INTERVAL_S: u64 = 4 * 60 * 60;
 
 macro_rules! get_pubkey_from_source {
     ($command_config:expr,  $matches:expr, $wallet_manager:expr, $field:ident) => {
@@ -216,11 +216,14 @@ async fn command_attach(
             return Ok(format!("Reported {} violations", reported_violations));
         };
         drop(blockstore);
-        std::thread::sleep(Duration::from_secs(
-            command_config
-                .scan_interval
-                .unwrap_or(DEFAULT_SCAN_INTERVAL_S),
-        ));
+        let scan_interval = command_config
+            .scan_interval
+            .unwrap_or(DEFAULT_SCAN_INTERVAL_S);
+        println_display(
+            config,
+            format!("Scanning again in {} seconds", scan_interval).to_string(),
+        );
+        std::thread::sleep(Duration::from_secs(scan_interval));
     }
 }
 

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -24,7 +24,7 @@ use {
         primitives::PodU64,
     },
     spl_record::state::RecordData,
-    spl_slashing::{
+    solana_slashing_program::{
         duplicate_block_proof::DuplicateBlockProofData,
         get_violation_report_address,
         instruction::{
@@ -225,7 +225,7 @@ async fn report_duplicate_block_violation(
         .value
     {
         if !report_account.data.is_empty()
-            && spl_slashing::check_id(&report_account.owner)
+            && solana_slashing_program::check_id(&report_account.owner)
             && ViolationReport::version(report_account.data()) > 0
         {
             println_display(
@@ -347,7 +347,7 @@ async fn command_close(
 
     let reports = config
         .rpc_client
-        .get_program_accounts_with_config(&spl_slashing::id(), gpa_config)
+        .get_program_accounts_with_config(&solana_slashing_program::id(), gpa_config)
         .await?;
     let mut early_reports = 0;
 
@@ -428,7 +428,7 @@ async fn command_display(
 
     let reports = config
         .rpc_client
-        .get_program_accounts_with_config(&spl_slashing::id(), gpa_config)
+        .get_program_accounts_with_config(&solana_slashing_program::id(), gpa_config)
         .await?;
 
     let mut displays = vec![];

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -187,7 +187,7 @@ async fn command_attach(
                 &[close_ix],
                 Some(&payer.pubkey()),
                 &[payer.clone(), proof_account],
-                config.program_client.get_latest_blockhash().await?,
+                config.rpc_client.get_latest_blockhash().await?,
             );
             if process_transaction(config, transaction).await?.is_some() {
                 println_display(config, "Closed proof account".to_string());
@@ -286,7 +286,7 @@ async fn report_duplicate_block_violation(
         &instructions,
         Some(&payer.pubkey()),
         &[payer.as_ref()],
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
     if let Some(_signature) = process_transaction(config, transaction).await? {
         let report_account = config.rpc_client.get_account(&pda).await?;
@@ -369,7 +369,7 @@ async fn command_close(
             &[close_ix],
             Some(&payer.pubkey()),
             &[payer.as_ref()],
-            config.program_client.get_latest_blockhash().await?,
+            config.rpc_client.get_latest_blockhash().await?,
         );
         let signature = process_transaction(config, transaction).await?;
 
@@ -479,7 +479,7 @@ async fn initialize_and_write_proof(
         ],
         Some(&payer.pubkey()),
         &signers,
-        config.program_client.get_latest_blockhash().await?,
+        config.rpc_client.get_latest_blockhash().await?,
     );
     if process_transaction(config, transaction).await?.is_some() {
         println_display(
@@ -505,7 +505,7 @@ async fn initialize_and_write_proof(
             &[write_ix],
             Some(&payer.pubkey()),
             &[&**payer],
-            config.program_client.get_latest_blockhash().await?,
+            config.rpc_client.get_latest_blockhash().await?,
         );
         writes.push(process_transaction(config, transaction));
         offset = offset.checked_add(chunk_size).unwrap();

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -202,7 +202,7 @@ async fn command_attach(
             let transaction = Transaction::new_signed_with_payer(
                 &[close_ix],
                 Some(&payer.pubkey()),
-                &[payer.clone(), proof_account],
+                &[payer.as_ref()],
                 config.rpc_client.get_latest_blockhash().await?,
             );
             if process_transaction(config, transaction).await?.is_some() {
@@ -522,7 +522,7 @@ async fn initialize_and_write_proof(
         let transaction = Transaction::new_signed_with_payer(
             &[write_ix],
             Some(&payer.pubkey()),
-            &[&*payer],
+            &[payer.as_ref()],
             config.rpc_client.get_latest_blockhash().await?,
         );
         writes.push(process_transaction(config, transaction));

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -1,0 +1,552 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    clap::{ArgMatches, CommandFactory, Parser},
+    futures::future::join_all,
+    solana_account_decoder::UiAccountEncoding,
+    solana_clap_v3_utils::keypair::pubkey_from_source,
+    solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+    solana_ledger::{
+        blockstore::Blockstore,
+        blockstore_options::{AccessType, BlockstoreOptions},
+        shred::layout,
+    },
+    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_sdk::{
+        account::ReadableAccount,
+        clock::Slot,
+        pubkey::Pubkey,
+        signature::{Keypair, Signature, Signer, SIGNATURE_BYTES},
+        transaction::Transaction,
+    },
+    spl_pod::{
+        bytemuck::{pod_from_bytes, pod_get_packed_len},
+        primitives::PodU64,
+    },
+    spl_record::state::RecordData,
+    spl_slashing::{
+        duplicate_block_proof::DuplicateBlockProofData,
+        get_violation_report_address,
+        instruction::{
+            close_violation_report, duplicate_block_proof_with_sigverify_and_prefund,
+            DuplicateBlockProofInstructionData,
+        },
+        state::{ProofType, SlashingProofData, ViolationReport},
+    },
+    std::{path::PathBuf, rc::Rc, sync::Arc, time::Duration},
+};
+
+mod config;
+use config::*;
+
+mod cli;
+use cli::*;
+
+mod output;
+use output::*;
+
+// Scan once a day
+const DEFAULT_SCAN_INTERVAL_S: u64 = 86400;
+
+macro_rules! get_pubkey_from_source {
+    ($command_config:expr,  $matches:expr, $wallet_manager:expr, $field:ident) => {
+        $command_config
+            .$field
+            .map(|source| {
+                pubkey_from_source($matches, &source, stringify!($field), $wallet_manager)
+            })
+            .transpose()
+            .map_err(|e| Error::from(e.to_string()))
+    };
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let cli = Cli::parse();
+    let matches = Cli::command().get_matches();
+    let mut wallet_manager = None;
+
+    let command = cli.command.clone();
+    let config = Config::new(cli, matches.clone(), &mut wallet_manager).await;
+
+    solana_logger::setup_with_default("solana=info");
+
+    let res = command
+        .execute(&config, &matches, &mut wallet_manager)
+        .await?;
+    println!("{}", res);
+
+    Ok(())
+}
+
+pub type CommandResult = Result<String, Error>;
+
+impl Command {
+    pub async fn execute(
+        self,
+        config: &Config,
+        matches: &ArgMatches,
+        wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+    ) -> CommandResult {
+        match self {
+            Command::Attach(command_config) => {
+                command_attach(config, command_config, matches, wallet_manager).await
+            }
+            Command::Close(command_config) => {
+                command_close(config, command_config, matches, wallet_manager).await
+            }
+            Command::Display(command_config) => {
+                command_display(config, command_config, matches, wallet_manager).await
+            }
+        }
+    }
+}
+
+async fn command_attach(
+    config: &Config,
+    command_config: AttachCli,
+    matches: &ArgMatches,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+) -> CommandResult {
+    let payer = config.fee_payer()?;
+    let reporter = get_pubkey_from_source!(command_config, matches, wallet_manager, reporter)?
+        .ok_or(Error::from("Reporter or default signer was not specified"))
+        .or(config.default_signer().map(|s| s.pubkey()))?;
+    let destination =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, destination)?
+            .ok_or(Error::from(
+                "Destination or default signer was not specified",
+            ))
+            .or(config.default_signer().map(|s| s.pubkey()))?;
+
+    let ledger_path = PathBuf::from(command_config.ledger);
+    let ledger_path = std::fs::canonicalize(&ledger_path).map_err(|err| {
+        Error::from(format!(
+            "Unable to access ledger path '{}': {}",
+            ledger_path.display(),
+            err
+        ))
+    })?;
+    let mut starting_slot = command_config.start_slot.unwrap_or(0);
+    let mut reported_violations = 0;
+
+    loop {
+        println_display(
+            config,
+            format!("\nChecking duplicate slots from {}", starting_slot),
+        );
+
+        let blockstore = Blockstore::open_with_options(
+            &ledger_path,
+            BlockstoreOptions {
+                access_type: AccessType::Secondary,
+                ..BlockstoreOptions::default()
+            },
+        )
+        .map_err(|err| {
+            Error::from(format!(
+                "Unable to open blockstore at {:?}: {:?}",
+                ledger_path, err
+            ))
+        })?;
+        let mut closable_proof_accounts = vec![];
+
+        for slot in blockstore.duplicate_slots_iterator(starting_slot)? {
+            if slot > command_config.end_slot.unwrap_or(u64::MAX) {
+                continue;
+            }
+
+            println_display(config, format!("\nDuplicate proof found for slot {}", slot));
+
+            match report_duplicate_block_violation(
+                config,
+                &blockstore,
+                &mut closable_proof_accounts,
+                &payer,
+                reporter,
+                destination,
+                slot,
+            )
+            .await
+            {
+                Ok(true) => reported_violations += 1,
+                Err(e) => eprintln_display(config, format!("Unable to report violation {:?}", e)),
+                _ => (),
+            }
+            starting_slot = slot + 1;
+        }
+
+        // Close any proof accounts, regardless of whether the report was successful
+        for proof_account in closable_proof_accounts {
+            let close_ix = spl_record::instruction::close_account(
+                &proof_account.pubkey(),
+                &payer.pubkey(),
+                &payer.pubkey(),
+            );
+            let transaction = Transaction::new_signed_with_payer(
+                &[close_ix],
+                Some(&payer.pubkey()),
+                &[payer.clone(), proof_account],
+                config.program_client.get_latest_blockhash().await?,
+            );
+            if process_transaction(config, transaction).await?.is_some() {
+                println_display(config, "Closed proof account".to_string());
+            }
+        }
+
+        if !command_config.continuous {
+            return Ok(format!("Reported {} violations", reported_violations));
+        };
+        drop(blockstore);
+        std::thread::sleep(Duration::from_secs(
+            command_config
+                .scan_interval
+                .unwrap_or(DEFAULT_SCAN_INTERVAL_S),
+        ));
+    }
+}
+
+async fn report_duplicate_block_violation(
+    config: &Config,
+    blockstore: &Blockstore,
+    closable_proof_accounts: &mut Vec<Arc<Keypair>>,
+    payer: &Arc<dyn Signer>,
+    reporter: Pubkey,
+    destination: Pubkey,
+    slot: Slot,
+) -> Result<bool, Error> {
+    // Check if this violation has already been reported
+    let node_pubkey = config.rpc_client.get_slot_leaders(slot, 1).await?[0];
+    let (pda, _) = get_violation_report_address(&node_pubkey, slot, ProofType::DuplicateBlockProof);
+    if let Some(report_account) = config
+        .rpc_client
+        .get_account_with_commitment(&pda, config.rpc_client.commitment())
+        .await?
+        .value
+    {
+        if !report_account.data.is_empty()
+            && spl_slashing::check_id(&report_account.owner)
+            && ViolationReport::version(report_account.data()) > 0
+        {
+            println_display(
+                config,
+                format!(
+                    "Duplicate block violation already reported for {} at {}",
+                    node_pubkey, slot
+                ),
+            );
+            return Ok(false);
+        }
+    }
+
+    // Write the proof on chain
+    let proof_account = Arc::new(Keypair::new());
+    closable_proof_accounts.push(proof_account.clone());
+    let proof = blockstore.get_duplicate_slot(slot).ok_or(Error::from(
+        "Unable to fetch duplicate proof from blockstore",
+    ))?;
+    let duplicate_proof = DuplicateBlockProofData {
+        shred1: proof.shred1.as_ref(),
+        shred2: proof.shred2.as_ref(),
+    };
+    let proof_data = duplicate_proof.pack_proof();
+    initialize_and_write_proof(
+        config,
+        payer,
+        &proof_account,
+        ProofType::DuplicateBlockProof,
+        &proof_data,
+    )
+    .await?;
+
+    // Submit the violation to the slashing program
+    let shred_1_merkle_root = layout::get_merkle_root(proof.shred1.as_ref()).unwrap();
+    let shred_2_merkle_root = layout::get_merkle_root(proof.shred2.as_ref()).unwrap();
+    let shred_1_signature = proof.shred1.as_ref()[..SIGNATURE_BYTES].try_into().unwrap();
+    let shred_2_signature = proof.shred2.as_ref()[..SIGNATURE_BYTES].try_into().unwrap();
+
+    let instruction_data = DuplicateBlockProofInstructionData {
+        offset: PodU64::from(RecordData::WRITABLE_START_INDEX as u64),
+        slot: PodU64::from(slot),
+        node_pubkey,
+        reporter,
+        destination,
+        shred_1_merkle_root,
+        shred_1_signature,
+        shred_2_merkle_root,
+        shred_2_signature,
+    };
+    let instructions = duplicate_block_proof_with_sigverify_and_prefund(
+        &proof_account.pubkey(),
+        &instruction_data,
+        Some(&payer.pubkey()),
+        &config.rent,
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&payer.pubkey()),
+        &[payer.as_ref()],
+        config.program_client.get_latest_blockhash().await?,
+    );
+    if let Some(_signature) = process_transaction(config, transaction).await? {
+        let report_account = config.rpc_client.get_account(&pda).await?;
+        let report: &ViolationReport =
+            pod_from_bytes(&report_account.data()[..std::mem::size_of::<ViolationReport>()])?;
+        println_display(
+            config,
+            ViolationReportOutput::from_report(pda, report, vec![]).to_string(),
+        );
+    }
+
+    Ok(true)
+}
+
+/// Close a violation report
+/// If `report_account` is specified we close the report account, otherwise we
+/// close any eligible accounts filtered by `reporter`, `destination`, or
+/// `node_pubkey`
+async fn command_close(
+    config: &Config,
+    command_config: CloseCli,
+    matches: &ArgMatches,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+) -> CommandResult {
+    let epoch = config.rpc_client.get_epoch_info().await?.epoch;
+    let report_account =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, report_account)?;
+    let node_pubkey =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, node_pubkey)?;
+    let reporter_pubkey =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, reporter)?;
+    let destination_pubkey =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, destination)?;
+    let payer = config.fee_payer()?;
+
+    let ignore_filter = |account_pubkey: Pubkey, report: &ViolationReport| {
+        report_account
+            .map(|pk| pk != account_pubkey)
+            .unwrap_or_default()
+            || node_pubkey
+                .map(|pk| pk != report.pubkey)
+                .unwrap_or_default()
+            || reporter_pubkey
+                .map(|pk| pk != report.reporter)
+                .unwrap_or_default()
+            || destination_pubkey
+                .map(|pk| pk != report.destination)
+                .unwrap_or_default()
+    };
+    let gpa_config = RpcProgramAccountsConfig {
+        account_config: RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64),
+            commitment: Some(config.rpc_client.commitment()),
+            ..RpcAccountInfoConfig::default()
+        },
+        ..RpcProgramAccountsConfig::default()
+    };
+
+    let reports = config
+        .rpc_client
+        .get_program_accounts_with_config(&spl_slashing::id(), gpa_config)
+        .await?;
+    let mut early_reports = 0;
+
+    let mut displays = vec![];
+    for (pubkey, report_account) in reports {
+        let report: &ViolationReport =
+            pod_from_bytes(&report_account.data()[..std::mem::size_of::<ViolationReport>()])?;
+        if report.epoch() + 3 > epoch {
+            early_reports += 1;
+            continue;
+        }
+        if ignore_filter(pubkey, report) {
+            continue;
+        }
+        let lamports = report_account.lamports;
+
+        let close_ix = close_violation_report(&pubkey, &report.destination);
+        let transaction = Transaction::new_signed_with_payer(
+            &[close_ix],
+            Some(&payer.pubkey()),
+            &[payer.as_ref()],
+            config.program_client.get_latest_blockhash().await?,
+        );
+        let signature = process_transaction(config, transaction).await?;
+
+        displays.push(CloseReportOutput {
+            report_account: pubkey,
+            pubkey: report.pubkey,
+            reporter: report.reporter,
+            destination: report.destination,
+            lamports,
+            signature,
+        });
+    }
+
+    Ok(format_output(
+        config,
+        "Close".to_string(),
+        CloseReportOutputList(early_reports, displays),
+    ))
+}
+
+/// Display violation reports
+/// If specified, we filter by `epoch`, `node_pubkey`, and `reporter`
+/// If verbose is specified we additionally deserialize the raw proof
+async fn command_display(
+    config: &Config,
+    command_config: DisplayCli,
+    matches: &ArgMatches,
+    wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
+) -> CommandResult {
+    let node_pubkey =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, node_pubkey)?;
+    let reporter_pubkey =
+        get_pubkey_from_source!(command_config, matches, wallet_manager, reporter)?;
+
+    let ignore_filter = |report: &ViolationReport| {
+        command_config
+            .epoch
+            .map(|e| e != report.epoch())
+            .unwrap_or_default()
+            || node_pubkey
+                .map(|pk| pk != report.pubkey)
+                .unwrap_or_default()
+            || reporter_pubkey
+                .map(|pk| pk != report.reporter)
+                .unwrap_or_default()
+    };
+
+    let gpa_config = RpcProgramAccountsConfig {
+        account_config: RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64),
+            commitment: Some(config.rpc_client.commitment()),
+            ..RpcAccountInfoConfig::default()
+        },
+        ..RpcProgramAccountsConfig::default()
+    };
+
+    let reports = config
+        .rpc_client
+        .get_program_accounts_with_config(&spl_slashing::id(), gpa_config)
+        .await?;
+
+    let mut displays = vec![];
+    for (pubkey, report_account) in reports {
+        let report: &ViolationReport =
+            pod_from_bytes(&report_account.data()[..std::mem::size_of::<ViolationReport>()])?;
+        if ignore_filter(report) {
+            continue;
+        }
+        let proof = report_account.data()[std::mem::size_of::<ViolationReport>()..].to_vec();
+        displays.push(ViolationReportOutput::from_report(pubkey, report, proof));
+    }
+
+    displays.sort_by(|a, b| a.slot.cmp(&b.slot));
+
+    Ok(format_output(
+        config,
+        "Display".to_string(),
+        ViolationReportListOutput(displays),
+    ))
+}
+
+async fn initialize_and_write_proof(
+    config: &Config,
+    payer: &Arc<dyn Signer>,
+    proof_account: &Keypair,
+    proof_type: ProofType,
+    proof_data: &[u8],
+) -> Result<(), Error> {
+    // Initialize account with the record program
+    let account_length = proof_type
+        .proof_account_length()
+        .saturating_add(pod_get_packed_len::<RecordData>());
+    let lamports = 1.max(config.rent.minimum_balance(account_length));
+    let signers: [&dyn Signer; 2] = [&**payer, proof_account];
+    let initialize_ix =
+        spl_record::instruction::initialize(&proof_account.pubkey(), &payer.pubkey());
+    let transaction = Transaction::new_signed_with_payer(
+        &[
+            solana_system_interface::instruction::create_account(
+                &payer.pubkey(),
+                &proof_account.pubkey(),
+                lamports,
+                account_length as u64,
+                &spl_record::id(),
+            ),
+            initialize_ix,
+        ],
+        Some(&payer.pubkey()),
+        &signers,
+        config.program_client.get_latest_blockhash().await?,
+    );
+    if process_transaction(config, transaction).await?.is_some() {
+        println_display(
+            config,
+            format!("Initialized proof account {}", proof_account.pubkey()),
+        )
+    }
+
+    // Write the proof
+    let mut offset = 0;
+    let chunk_size = 800;
+    let proof_len = proof_data.len();
+    let mut writes = vec![];
+    while offset < proof_len {
+        let end = std::cmp::min(offset.checked_add(chunk_size).unwrap(), proof_len);
+        let write_ix = spl_record::instruction::write(
+            &proof_account.pubkey(),
+            &payer.pubkey(),
+            offset as u64,
+            &proof_data[offset..end],
+        );
+        let transaction = Transaction::new_signed_with_payer(
+            &[write_ix],
+            Some(&payer.pubkey()),
+            &[&**payer],
+            config.program_client.get_latest_blockhash().await?,
+        );
+        writes.push(process_transaction(config, transaction));
+        offset = offset.checked_add(chunk_size).unwrap();
+    }
+    join_all(writes)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    Ok(())
+}
+
+async fn process_transaction(
+    config: &Config,
+    transaction: Transaction,
+) -> Result<Option<Signature>, Error> {
+    if config.dry_run {
+        let simulation_data = config.rpc_client.simulate_transaction(&transaction).await?;
+
+        if config.verbose() {
+            if let Some(logs) = simulation_data.value.logs {
+                for log in logs {
+                    println!("    {}", log);
+                }
+            }
+
+            println!(
+                "\nSimulation succeeded, consumed {} compute units",
+                simulation_data.value.units_consumed.unwrap()
+            );
+        } else {
+            println_display(config, "Simulation succeeded".to_string());
+        }
+
+        Ok(None)
+    } else {
+        Ok(Some(
+            config
+                .rpc_client
+                .send_and_confirm_transaction_with_spinner(&transaction)
+                .await?,
+        ))
+    }
+}

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -169,7 +169,7 @@ async fn command_attach(
 
         for slot in blockstore.duplicate_slots_iterator(starting_slot)? {
             if slot > command_config.end_slot.unwrap_or(u64::MAX) {
-                continue;
+                break;
             }
 
             println_display(config, format!("\nDuplicate proof found for slot {}", slot));

--- a/clients/cli/src/main.rs
+++ b/clients/cli/src/main.rs
@@ -186,7 +186,9 @@ async fn command_attach(
             .await
             {
                 Ok(true) => reported_violations += 1,
-                Err(e) => eprintln_display(config, format!("Unable to report violation {:?}", e)),
+                Err(e) => eprintln_display(config, format!("
+                Failed to submit duplicate block report for slot {slot}: {:?}, please run the following command to reattempt the report submission:
+                  spl-slashing attach -l <LEDGER> --start-slot {slot}--end-slot {slot}", e)),
                 _ => (),
             }
             starting_slot = slot + 1;

--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -1,0 +1,282 @@
+use {
+    crate::config::Config,
+    console::style,
+    serde::{Deserialize, Serialize},
+    serde_with::{serde_as, DisplayFromStr},
+    solana_cli_output::{display::writeln_name_value, QuietDisplay, VerboseDisplay},
+    solana_ledger::{
+        blockstore_meta::{DuplicateSlotProof, ErasureMeta},
+        shred::{Payload, Shred, ShredType},
+    },
+    solana_sdk::{
+        clock::{Epoch, Slot},
+        pubkey::Pubkey,
+        signature::Signature,
+    },
+    spl_slashing::{
+        duplicate_block_proof::DuplicateBlockProofData,
+        state::{ProofType, ViolationReport},
+    },
+    std::fmt::{Display, Formatter, Result, Write},
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CommandOutput<T>
+where
+    T: Serialize + Display + QuietDisplay + VerboseDisplay,
+{
+    pub(crate) command_name: String,
+    pub(crate) command_output: T,
+}
+
+impl<T> Display for CommandOutput<T>
+where
+    T: Serialize + Display + QuietDisplay + VerboseDisplay,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.command_output, f)
+    }
+}
+
+impl<T> QuietDisplay for CommandOutput<T>
+where
+    T: Serialize + Display + QuietDisplay + VerboseDisplay,
+{
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        QuietDisplay::write_str(&self.command_output, w)
+    }
+}
+
+impl<T> VerboseDisplay for CommandOutput<T>
+where
+    T: Serialize + Display + QuietDisplay + VerboseDisplay,
+{
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        writeln_name_value(w, "Command:", &self.command_name)?;
+        VerboseDisplay::write_str(&self.command_output, w)
+    }
+}
+
+pub fn format_output<T>(config: &Config, command_name: String, command_output: T) -> String
+where
+    T: Serialize + Display + QuietDisplay + VerboseDisplay,
+{
+    config.output_format.formatted_string(&CommandOutput {
+        command_name,
+        command_output,
+    })
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloseReportOutput {
+    #[serde_as(as = "DisplayFromStr")]
+    pub report_account: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    pub pubkey: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    pub reporter: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    pub destination: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    pub lamports: u64,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub signature: Option<Signature>,
+}
+
+impl QuietDisplay for CloseReportOutput {}
+impl VerboseDisplay for CloseReportOutput {}
+
+impl Display for CloseReportOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        writeln!(f)?;
+        writeln_name_value(
+            f,
+            "Closed report account ",
+            &self.report_account.to_string(),
+        )?;
+        writeln_name_value(f, "  Violator:", &self.pubkey.to_string())?;
+        writeln_name_value(f, "  Reporter:", &self.reporter.to_string())?;
+        writeln!(
+            f,
+            "Reclaimed {} to destination {}",
+            &self.lamports.to_string(),
+            &self.destination.to_string()
+        )?;
+        if let Some(signature) = self.signature {
+            writeln_name_value(f, "  Signature:", &signature.to_string())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CloseReportOutputList(pub u64, pub Vec<CloseReportOutput>);
+
+impl QuietDisplay for CloseReportOutputList {}
+impl VerboseDisplay for CloseReportOutputList {}
+
+impl Display for CloseReportOutputList {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut lamports = 0;
+        for report in self.1.iter() {
+            lamports += report.lamports;
+            report.fmt(f)?;
+        }
+
+        writeln!(f)?;
+        writeln_name_value(f, "Reports too soon to close:", &self.0.to_string())?;
+        writeln_name_value(f, "Closed reports:", &self.1.len().to_string())?;
+        writeln_name_value(f, "Total lamports recovered:", &lamports.to_string())?;
+
+        Ok(())
+    }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViolationReportOutput {
+    #[serde_as(as = "DisplayFromStr")]
+    pub report_address: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    pub reporter: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    pub destination: Pubkey,
+    pub epoch: Epoch,
+    #[serde_as(as = "DisplayFromStr")]
+    pub pubkey: Pubkey,
+    pub slot: Slot,
+    #[serde_as(as = "DisplayFromStr")]
+    pub violation_type: ProofType,
+    pub proof: Vec<u8>,
+}
+
+impl ViolationReportOutput {
+    pub(crate) fn from_report(
+        report_address: Pubkey,
+        report: &ViolationReport,
+        proof: Vec<u8>,
+    ) -> Self {
+        Self {
+            report_address,
+            reporter: report.reporter,
+            destination: report.destination,
+            epoch: Epoch::from(report.epoch),
+            pubkey: report.pubkey,
+            slot: Slot::from(report.slot),
+            violation_type: ProofType::from(report.violation_type),
+            proof,
+        }
+    }
+
+    fn write_common(&self, w: &mut dyn Write) -> Result {
+        writeln!(w)?;
+        writeln!(w, "{}", style("Slashing violation report").bold())?;
+        writeln_name_value(
+            w,
+            "  Report account address:",
+            &self.report_address.to_string(),
+        )?;
+        writeln_name_value(w, "  Violator:", &self.pubkey.to_string())?;
+        writeln_name_value(w, "  Violation Type:", self.violation_type.violation_str())?;
+        writeln_name_value(w, "  Violation Slot:", &self.slot.to_string())?;
+        writeln_name_value(w, "  Reporter:", &self.reporter.to_string())?;
+        writeln_name_value(w, "  Reported Epoch:", &self.epoch.to_string())?;
+        writeln_name_value(w, "  Destination:", &self.destination.to_string())
+    }
+
+    fn display_duplicate_block_proof(w: &mut dyn Write, proof: DuplicateSlotProof) -> Result {
+        let shred1 = Shred::new_from_serialized_shred(proof.shred1).unwrap();
+        let shred2 = Shred::new_from_serialized_shred(proof.shred2).unwrap();
+
+        for (i, shred) in [&shred1, &shred2].iter().enumerate() {
+            write!(w, "    Shred{}: ", i + 1)?;
+            writeln!(
+                w,
+                "fec_set_index {}, index {}, shred_type {:?}\n       \
+             version {}, merkle_root {:?}, chained_merkle_root {:?}, last_in_slot {}",
+                shred.fec_set_index(),
+                shred.index(),
+                shred.shred_type(),
+                shred.version(),
+                shred.merkle_root().ok(),
+                shred.chained_merkle_root().ok(),
+                shred.last_in_slot(),
+            )?;
+            writeln!(w, "       payload: {:?}", shred.payload())?;
+        }
+
+        if shred1.shred_type() == ShredType::Code && shred2.shred_type() == ShredType::Code {
+            writeln!(
+                w,
+                "    Erasure consistency {}",
+                ErasureMeta::check_erasure_consistency(&shred1, &shred2)
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl QuietDisplay for ViolationReportOutput {}
+
+impl VerboseDisplay for ViolationReportOutput {
+    fn write_str(&self, w: &mut dyn Write) -> Result {
+        self.write_common(w)?;
+        match self.violation_type {
+            ProofType::DuplicateBlockProof => {
+                let duplicate_proof: DuplicateBlockProofData =
+                    DuplicateBlockProofData::unpack_proof(&self.proof).unwrap();
+                let duplicate_slot_proof = DuplicateSlotProof {
+                    shred1: Payload::Unique(Vec::from(duplicate_proof.shred1)),
+                    shred2: Payload::Unique(Vec::from(duplicate_proof.shred2)),
+                };
+                Self::display_duplicate_block_proof(w, duplicate_slot_proof)
+            }
+            ProofType::InvalidType => {
+                panic!("Invalid violation type for {}", self.report_address);
+            }
+        }
+    }
+}
+
+impl Display for ViolationReportOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        self.write_common(f)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ViolationReportListOutput(pub Vec<ViolationReportOutput>);
+
+impl QuietDisplay for ViolationReportListOutput {}
+
+impl VerboseDisplay for ViolationReportListOutput {
+    fn write_str(&self, w: &mut dyn Write) -> Result {
+        for report in self.0.iter() {
+            VerboseDisplay::write_str(report, w)?;
+        }
+
+        writeln!(w)?;
+        writeln_name_value(w, "Open reports:", &self.0.len().to_string())?;
+
+        Ok(())
+    }
+}
+
+impl Display for ViolationReportListOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        for report in self.0.iter() {
+            report.fmt(f)?;
+        }
+
+        writeln!(f)?;
+        writeln_name_value(f, "Open reports:", &self.0.len().to_string())?;
+
+        Ok(())
+    }
+}

--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -13,7 +13,7 @@ use {
         pubkey::Pubkey,
         signature::Signature,
     },
-    spl_slashing::{
+    solana_slashing_program::{
         duplicate_block_proof::DuplicateBlockProofData,
         state::{ProofType, ViolationReport},
     },

--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -80,7 +80,6 @@ pub struct CloseReportOutput {
     pub reporter: Pubkey,
     #[serde_as(as = "DisplayFromStr")]
     pub destination: Pubkey,
-    #[serde_as(as = "DisplayFromStr")]
     pub lamports: u64,
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub signature: Option<Signature>,
@@ -92,16 +91,12 @@ impl VerboseDisplay for CloseReportOutput {}
 impl Display for CloseReportOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         writeln!(f)?;
-        writeln_name_value(
-            f,
-            "Closed report account ",
-            &self.report_account.to_string(),
-        )?;
+        writeln_name_value(f, "Closed report account", &self.report_account.to_string())?;
         writeln_name_value(f, "  Violator:", &self.pubkey.to_string())?;
         writeln_name_value(f, "  Reporter:", &self.reporter.to_string())?;
         writeln!(
             f,
-            "Reclaimed {} to destination {}",
+            "  Reclaimed {} to destination {}",
             &self.lamports.to_string(),
             &self.destination.to_string()
         )?;
@@ -194,11 +189,11 @@ impl ViolationReportOutput {
         let shred2 = Shred::new_from_serialized_shred(proof.shred2).unwrap();
 
         for (i, shred) in [&shred1, &shred2].iter().enumerate() {
-            write!(w, "    Shred{}: ", i + 1)?;
             writeln!(
                 w,
-                "fec_set_index {}, index {}, shred_type {:?}\n       \
+                "    Shred{}: fec_set_index {}, index {}, shred_type {:?}\n       \
              version {}, merkle_root {:?}, chained_merkle_root {:?}, last_in_slot {}",
+                i + 1,
                 shred.fec_set_index(),
                 shred.index(),
                 shred.shred_type(),

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spl-slashing"
+name = "solana-slashing-program"
 version = "0.1.0"
 description = "Solana Program Library Slashing"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -26,7 +26,7 @@ use {
         primitives::PodU64,
     },
     spl_record::{instruction as record, state::RecordData},
-    spl_slashing::{
+    solana_slashing_program::{
         duplicate_block_proof::DuplicateBlockProofData,
         error::SlashingError,
         id,
@@ -44,7 +44,7 @@ const SLOT: Slot = 53084024;
 const EPOCH: Epoch = 42;
 
 fn program_test() -> ProgramTest {
-    let mut program_test = ProgramTest::new("spl_slashing", id(), processor!(process_instruction));
+    let mut program_test = ProgramTest::new("solana_slashing_program", id(), processor!(process_instruction));
     program_test.add_program(
         "spl_record",
         spl_record::id(),
@@ -339,7 +339,7 @@ async fn valid_proof_data() {
             &slot.to_le_bytes(),
             &[u8::from(ProofType::DuplicateBlockProof)],
         ],
-        &spl_slashing::id(),
+        &solana_slashing_program::id(),
     );
     let report_account = context
         .banks_client
@@ -436,7 +436,7 @@ async fn valid_proof_coding() {
             &slot.to_le_bytes(),
             &[u8::from(ProofType::DuplicateBlockProof)],
         ],
-        &spl_slashing::id(),
+        &solana_slashing_program::id(),
     );
     let report_account = context
         .banks_client
@@ -835,7 +835,7 @@ async fn double_report() {
             &slot.to_le_bytes(),
             &[u8::from(ProofType::DuplicateBlockProof)],
         ],
-        &spl_slashing::id(),
+        &solana_slashing_program::id(),
     );
     let report_account = context
         .banks_client
@@ -916,7 +916,7 @@ async fn double_report() {
             &slot.to_le_bytes(),
             &[u8::from(ProofType::DuplicateBlockProof)],
         ],
-        &spl_slashing::id(),
+        &solana_slashing_program::id(),
     );
     let report_account = context
         .banks_client
@@ -970,7 +970,7 @@ async fn close_report_destination_and_early() {
             &slot.to_le_bytes(),
             &[u8::from(ProofType::DuplicateBlockProof)],
         ],
-        &spl_slashing::id(),
+        &solana_slashing_program::id(),
     );
 
     // Trying to create an account with the destination set to the report account

--- a/program/tests/duplicate_block_proof.rs
+++ b/program/tests/duplicate_block_proof.rs
@@ -21,11 +21,6 @@ use {
         transaction::{Transaction, TransactionError},
     },
     solana_signature::SIGNATURE_BYTES,
-    spl_pod::{
-        bytemuck::{pod_from_bytes, pod_get_packed_len},
-        primitives::PodU64,
-    },
-    spl_record::{instruction as record, state::RecordData},
     solana_slashing_program::{
         duplicate_block_proof::DuplicateBlockProofData,
         error::SlashingError,
@@ -37,6 +32,11 @@ use {
         processor::process_instruction,
         state::{ProofType, SlashingProofData, ViolationReport},
     },
+    spl_pod::{
+        bytemuck::{pod_from_bytes, pod_get_packed_len},
+        primitives::PodU64,
+    },
+    spl_record::{instruction as record, state::RecordData},
     std::{assert_ne, sync::Arc},
 };
 
@@ -44,7 +44,11 @@ const SLOT: Slot = 53084024;
 const EPOCH: Epoch = 42;
 
 fn program_test() -> ProgramTest {
-    let mut program_test = ProgramTest::new("solana_slashing_program", id(), processor!(process_instruction));
+    let mut program_test = ProgramTest::new(
+        "solana_slashing_program",
+        id(),
+        processor!(process_instruction),
+    );
     program_test.add_program(
         "spl_record",
         spl_record::id(),

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -58,4 +58,5 @@ devnet
 testnet
 RPC
 localhost
-
+blockstore
+TPS

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -36,7 +36,7 @@ offchain
 keypair/S
 decrypt/SGD
 lamport/S
-validator/S
+validator/SM
 pubkey/S
 sysvar/S
 timestamp/S
@@ -54,3 +54,8 @@ retransmitter/SM
 FEC
 sigverify
 prefund/GD
+devnet
+testnet
+RPC
+localhost
+


### PR DESCRIPTION
Adds the slashing client with 3 commands:
- `display`, displays all open slashing reports, optionally filtered by violator, epoch or reporter
- `close`, close all open slashing reports, optionally filtered by report account, reporter or destination
- `attach`, attach to the ledger of a validator and scan and submit reports. can be run in continuous mode with a specified scan interval (default is once a day)

Future work will implement a `standalone` mode which will connect to gossip/turbine and detect violations without input from a running validator.

An example of a run in continuous mode (10 second scan interval for the purpose of this screenshot):
![image](https://github.com/user-attachments/assets/2d82c512-5975-492f-9e2e-fe98b80bae88)
